### PR TITLE
feat: things without an account are public by default; resolve sensor display name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ staticfiles/
 .envrc
 .agents-bootstrap
 AGENTS.md
+.superpowers/

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,8 +3,9 @@ from datetime import datetime
 from django.db.models import Max
 from rest_framework import serializers
 
-from base.models import ThingsModel, ThingsTagsModel, SensorsModel, ThingsSensorsTagsModel, ThingsSensorsTagsModel, \
-                        AccountsModel, AccountsThingsModel, ThingsSensorsModel, AccountsThingsModel, ThingsSensorsDataModel
+from base.models import ThingsModel, ThingsTagsModel, SensorsModel, ThingsSensorsTagsModel, \
+                        AccountsModel, AccountsThingsModel, ThingsSensorsModel, ThingsSensorsDataModel, \
+                        get_thing_sensors_with_display_name, get_thing_account
 
 class ThingSerializer(serializers.ModelSerializer):
     class Meta:
@@ -54,35 +55,43 @@ class DataThingsSerializer(serializers.ModelSerializer):
     thingtags = serializers.SerializerMethodField()
 
     class Meta:
-        model = ThingsSensorsModel
+        model = ThingsModel
         fields = ('thing', 'uuid', 'lastupdate', 'account', 'sensors', 'thingtags')
-    
+
     def get_thing(self, obj):
-        return obj.id_thing.name
+        return obj.name
 
     def get_uuid(self, obj):
-        return obj.id_thing.uuid
+        return obj.uuid
 
     def get_account(self, obj):
-        serializer = AccountSerializer(obj.id_account)
-        return serializer.data
+        account = get_thing_account(obj)
+
+        if not account:
+            return {
+                "username": None,
+                "city": "não registrado",
+                "state": "",
+                "country": "NR",
+            }
+
+        return AccountSerializer(account).data
 
     def get_sensors(self, obj):
-        #thing_sensors = ThingsSensorsModel.objects.filter(id_thing = obj.id_thing)
-        #sensor_ids = [ts.id_sensor_id for ts in thing_sensors]
-        sensor_ids = ThingsSensorsModel.objects.filter(id_thing = obj.id_thing).values_list("id_sensor_id", flat=True)
-
-        sensors = SensorsModel.objects.filter(id__in = sensor_ids)
-        return SensorSerializer(sensors, many = True).data
+        thing_sensors = get_thing_sensors_with_display_name(obj)
+        return [
+            {"id": ts.id_sensor_id, "name": ts.display_name}
+            for ts in thing_sensors
+        ]
 
     def get_thingtags(self, obj):
-        thing_tags = ThingsTagsModel.objects.filter(id_thing = obj.id_thing)
+        thing_tags = ThingsTagsModel.objects.filter(id_thing = obj)
         return SensorSerializer(thing_tags, many = True).data
 
     def get_lastupdate(self, obj):
-        thingsensor_ids = ThingsSensorsModel.objects.filter(id_thing = obj.id_thing)
+        thingsensor_ids = ThingsSensorsModel.objects.filter(id_thing = obj)
         lastread = ThingsSensorsDataModel.objects.filter(id_thingsensor__in = thingsensor_ids).aggregate(Max('dtread'))['dtread__max']
-       
+
         return lastread.strftime("%d/%m/%Y %H:%M:%S") if lastread else "---"
 
 class DataStatsSerializer(serializers.Serializer):

--- a/api/tests.py
+++ b/api/tests.py
@@ -270,3 +270,41 @@ class GetFiltersFallbackPlaceholderTests(SimpleTestCase):
             filters["country"]("NR"),
             Q(accountsthings__isnull=True),
         )
+
+
+class FilterThingsSensorsTests(SimpleTestCase):
+    """The "sensor" search filter is fed the resolved display name clicked
+    in the listing (thingssensors.name when set, else sensors.name) — it
+    must match on that same resolved name, not the raw catalog name, or a
+    custom-named sensor's link returns zero things."""
+
+    @patch('api.views.ThingsSensorsModel.objects')
+    def test_public_matches_by_coalesced_display_name(self, mock_ts_objects):
+        mock_annotated = MagicMock()
+        mock_ts_objects.annotate.return_value = mock_annotated
+        mock_filtered = MagicMock()
+        mock_annotated.filter.return_value = mock_filtered
+        mock_filtered.values_list.return_value = [1, 2]
+
+        result = PublicThingsViewSets().filter_things_sensors("custom-name")
+
+        annotate_kwargs = mock_ts_objects.annotate.call_args.kwargs
+        self.assertIsInstance(annotate_kwargs['display_name'], Coalesce)
+        mock_annotated.filter.assert_called_once_with(display_name="custom-name")
+        mock_filtered.values_list.assert_called_once_with("id_thing_id", flat=True)
+        self.assertEqual(result, [1, 2])
+
+    @patch('api.views.ThingsSensorsModel.objects')
+    def test_private_matches_by_coalesced_display_name(self, mock_ts_objects):
+        mock_annotated = MagicMock()
+        mock_ts_objects.annotate.return_value = mock_annotated
+        mock_filtered = MagicMock()
+        mock_annotated.filter.return_value = mock_filtered
+        mock_filtered.values_list.return_value = [3]
+
+        result = PrivateThingsViewSets().filter_things_sensors("custom-name")
+
+        annotate_kwargs = mock_ts_objects.annotate.call_args.kwargs
+        self.assertIsInstance(annotate_kwargs['display_name'], Coalesce)
+        mock_annotated.filter.assert_called_once_with(display_name="custom-name")
+        self.assertEqual(result, [3])

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,8 +1,10 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.db.models import Q
 from django.test import SimpleTestCase
 
+from api.serializers import DataThingsSerializer
 from api.views import PublicThingsViewSets
 
 
@@ -25,3 +27,64 @@ class PublicThingsGetQuerysetTests(SimpleTestCase):
         self.assertEqual(called_args[0], expected_q)
         mock_filtered.distinct.assert_called_once()
         self.assertEqual(result, mock_filtered)
+
+
+class DataThingsSerializerGetAccountTests(SimpleTestCase):
+    @patch('api.serializers.get_thing_account')
+    def test_returns_fallback_when_no_account(self, mock_get_thing_account):
+        mock_get_thing_account.return_value = None
+        obj = SimpleNamespace(id=1, name="thing-1", uuid="uuid-1")
+
+        result = DataThingsSerializer().get_account(obj)
+
+        mock_get_thing_account.assert_called_once_with(obj)
+        self.assertEqual(result, {
+            "username": None,
+            "city": "não registrado",
+            "state": "",
+            "country": "NR",
+        })
+
+    @patch('api.serializers.get_thing_account')
+    def test_returns_account_data_when_account_exists(self, mock_get_thing_account):
+        mock_get_thing_account.return_value = SimpleNamespace(
+            username="acc1", city="Curitiba", state="PR", country="BR"
+        )
+        obj = SimpleNamespace(id=1, name="thing-1", uuid="uuid-1")
+
+        result = DataThingsSerializer().get_account(obj)
+
+        self.assertEqual(result, {
+            "username": "acc1",
+            "city": "Curitiba",
+            "state": "PR",
+            "country": "BR",
+        })
+
+
+class DataThingsSerializerGetSensorsTests(SimpleTestCase):
+    @patch('api.serializers.get_thing_sensors_with_display_name')
+    def test_returns_id_and_resolved_display_name(self, mock_get_thing_sensors):
+        mock_get_thing_sensors.return_value = [
+            SimpleNamespace(id_sensor_id=10, display_name="Custom Name"),
+            SimpleNamespace(id_sensor_id=11, display_name="Temperature"),
+        ]
+        obj = SimpleNamespace(id=1)
+
+        result = DataThingsSerializer().get_sensors(obj)
+
+        mock_get_thing_sensors.assert_called_once_with(obj)
+        self.assertEqual(result, [
+            {"id": 10, "name": "Custom Name"},
+            {"id": 11, "name": "Temperature"},
+        ])
+
+
+class DataThingsSerializerThingFieldsTests(SimpleTestCase):
+    def test_get_thing_returns_name_from_obj(self):
+        obj = SimpleNamespace(name="thing-1", uuid="uuid-1")
+        self.assertEqual(DataThingsSerializer().get_thing(obj), "thing-1")
+
+    def test_get_uuid_returns_uuid_from_obj(self):
+        obj = SimpleNamespace(name="thing-1", uuid="uuid-1")
+        self.assertEqual(DataThingsSerializer().get_uuid(obj), "uuid-1")

--- a/api/tests.py
+++ b/api/tests.py
@@ -215,3 +215,58 @@ class DataViewSetsCheckPublicGateTests(SimpleTestCase):
         )
         mock_filtered.exists.assert_called_once()
         self.assertIsNone(result)
+
+
+class GetFiltersFallbackPlaceholderTests(SimpleTestCase):
+    """Clicking the "não registrado"/"NR" placeholders shown for accountless
+    things must return things with no account at all, not a literal
+    equality match against Accounts.city/country (which never holds those
+    placeholder strings)."""
+
+    def test_public_city_placeholder_matches_accountless_things(self):
+        filters = PublicThingsViewSets().get_filters()
+
+        self.assertEqual(
+            filters["city"]("não registrado"),
+            Q(accountsthings__isnull=True),
+        )
+
+    def test_public_city_real_value_still_matches_by_equality(self):
+        filters = PublicThingsViewSets().get_filters()
+
+        self.assertEqual(
+            filters["city"]("Curitiba"),
+            Q(accountsthings__id_account__city="Curitiba"),
+        )
+
+    def test_public_country_placeholder_matches_accountless_things(self):
+        filters = PublicThingsViewSets().get_filters()
+
+        self.assertEqual(
+            filters["country"]("NR"),
+            Q(accountsthings__isnull=True),
+        )
+
+    def test_public_country_real_value_still_matches_by_equality(self):
+        filters = PublicThingsViewSets().get_filters()
+
+        self.assertEqual(
+            filters["country"]("BR"),
+            Q(accountsthings__id_account__country="BR"),
+        )
+
+    def test_private_city_placeholder_matches_accountless_things(self):
+        filters = PrivateThingsViewSets().get_filters()
+
+        self.assertEqual(
+            filters["city"]("não registrado"),
+            Q(accountsthings__isnull=True),
+        )
+
+    def test_private_country_placeholder_matches_accountless_things(self):
+        filters = PrivateThingsViewSets().get_filters()
+
+        self.assertEqual(
+            filters["country"]("NR"),
+            Q(accountsthings__isnull=True),
+        )

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,11 +1,14 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from django.core.exceptions import FieldError
 from django.db.models import Q
+from django.db.models.functions import Coalesce
 from django.test import SimpleTestCase
 
 from api.serializers import DataThingsSerializer
-from api.views import PublicThingsViewSets
+from api.views import PublicThingsViewSets, PrivateThingsViewSets, DataViewSets
+from base.models import ThingsModel
 
 
 class PublicThingsGetQuerysetTests(SimpleTestCase):
@@ -88,3 +91,127 @@ class DataThingsSerializerThingFieldsTests(SimpleTestCase):
     def test_get_uuid_returns_uuid_from_obj(self):
         obj = SimpleNamespace(name="thing-1", uuid="uuid-1")
         self.assertEqual(DataThingsSerializer().get_uuid(obj), "uuid-1")
+
+
+class PrivateThingsGetQuerysetTests(SimpleTestCase):
+    @patch('api.views.AccountsModel.objects')
+    @patch('api.views.ThingsModel.objects')
+    def test_filters_things_via_accountsthings_relation(self, mock_things_objects, mock_accounts_objects):
+        mock_account = SimpleNamespace(id=5)
+        mock_accounts_objects.get.return_value = mock_account
+
+        mock_filtered = MagicMock()
+        mock_things_objects.filter.return_value = mock_filtered
+        mock_filtered.distinct.return_value = mock_filtered
+
+        view = PrivateThingsViewSets()
+        result = view.get_queryset(params={}, user="someuser")
+
+        mock_accounts_objects.get.assert_called_once_with(username="someuser")
+        called_kwargs = mock_things_objects.filter.call_args.kwargs
+        self.assertEqual(called_kwargs, {
+            "accountsthings__id_account__status": True,
+            "accountsthings__id_account__id_plan__ispublic": False,
+            "accountsthings__id_account": mock_account,
+        })
+        mock_filtered.distinct.assert_called_once()
+        self.assertEqual(result, mock_filtered)
+
+
+class GetFiltersFieldPathTests(SimpleTestCase):
+    def _assert_filters_resolve_against_thingsmodel(self, filters):
+        for key, filter_func in filters.items():
+            q = filter_func("some-value")
+            try:
+                ThingsModel.objects.filter(q)
+            except FieldError as e:
+                self.fail("filter '%s' produced a Q object with an invalid "
+                          "field path for ThingsModel: %s" % (key, e))
+
+    def test_public_things_filters_resolve_against_thingsmodel(self):
+        view = PublicThingsViewSets()
+        self._assert_filters_resolve_against_thingsmodel(view.get_filters())
+
+    def test_private_things_filters_resolve_against_thingsmodel(self):
+        view = PrivateThingsViewSets()
+        self._assert_filters_resolve_against_thingsmodel(view.get_filters())
+
+
+class DataViewSetsSensorResolutionTests(SimpleTestCase):
+    @patch('api.views.AccountsThingsModel.objects')
+    @patch('api.views.ThingsSensorsModel.objects')
+    def test_resolves_sensor_by_coalesced_display_name(self, mock_ts_objects, mock_accountsthings_objects):
+        mock_annotated = MagicMock()
+        mock_ts_objects.annotate.return_value = mock_annotated
+        mock_thingsensor = SimpleNamespace(pk=42)
+        mock_annotated.get.return_value = mock_thingsensor
+
+        # short-circuit the rest of get_queryset via the (still isPublic=False,
+        # thus unchanged) checkPublic gate
+        mock_filtered = MagicMock()
+        mock_filtered.__bool__.return_value = False
+        mock_filtered.exists.return_value = False
+        mock_accountsthings_objects.filter.return_value = mock_filtered
+
+        view = DataViewSets()
+        view.isPublic = False
+        request = SimpleNamespace(data={"thing": "uuid-1", "sensor": "custom-name"})
+
+        view.get_queryset(request)
+
+        annotate_kwargs = mock_ts_objects.annotate.call_args.kwargs
+        self.assertIsInstance(annotate_kwargs['display_name'], Coalesce)
+
+        mock_annotated.get.assert_called_once_with(
+            id_thing__uuid="uuid-1",
+            display_name="custom-name",
+        )
+
+
+class DataViewSetsCheckPublicGateTests(SimpleTestCase):
+    @patch('api.views.ThingsModel.objects')
+    def test_public_gate_allows_things_without_account(self, mock_things_objects):
+        mock_filtered = MagicMock()
+        mock_things_objects.filter.return_value = mock_filtered
+        mock_filtered2 = MagicMock()
+        mock_filtered.filter.return_value = mock_filtered2
+        mock_filtered2.exists.return_value = False
+
+        view = DataViewSets()
+        view.isPublic = True
+        # no "sensor" key: skips the ThingsSensorsModel lookup entirely
+        request = SimpleNamespace(data={"thing": "uuid-1"})
+
+        result = view.get_queryset(request)
+
+        mock_things_objects.filter.assert_called_once_with(uuid="uuid-1")
+
+        expected_q = (
+            Q(accountsthings__isnull=True) |
+            Q(accountsthings__id_account__status=True,
+              accountsthings__id_account__id_plan__ispublic=True)
+        )
+        filter_call_args, _ = mock_filtered.filter.call_args
+        self.assertEqual(filter_call_args[0], expected_q)
+        mock_filtered2.exists.assert_called_once()
+        self.assertIsNone(result)
+
+    @patch('api.views.AccountsThingsModel.objects')
+    def test_private_gate_behavior_is_unchanged(self, mock_accountsthings_objects):
+        mock_filtered = MagicMock()
+        mock_accountsthings_objects.filter.return_value = mock_filtered
+        mock_filtered.__bool__.return_value = False
+        mock_filtered.exists.return_value = False
+
+        view = DataViewSets()
+        view.isPublic = False
+        request = SimpleNamespace(data={"thing": "uuid-1"})
+
+        result = view.get_queryset(request)
+
+        mock_accountsthings_objects.filter.assert_called_once_with(
+            id_thing__uuid="uuid-1",
+            id_account__id_plan__ispublic=False,
+        )
+        mock_filtered.exists.assert_called_once()
+        self.assertIsNone(result)

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,3 +1,27 @@
-from django.test import TestCase
+from unittest.mock import MagicMock, patch
 
-# Create your tests here.
+from django.db.models import Q
+from django.test import SimpleTestCase
+
+from api.views import PublicThingsViewSets
+
+
+class PublicThingsGetQuerysetTests(SimpleTestCase):
+    @patch('api.views.ThingsModel.objects')
+    def test_includes_things_without_account_or_with_public_active_account(self, mock_objects):
+        mock_filtered = MagicMock()
+        mock_objects.filter.return_value = mock_filtered
+        mock_filtered.distinct.return_value = mock_filtered
+
+        view = PublicThingsViewSets()
+        result = view.get_queryset(params={})
+
+        expected_q = (
+            Q(accountsthings__isnull=True) |
+            Q(accountsthings__id_account__status=True,
+              accountsthings__id_account__id_plan__ispublic=True)
+        )
+        called_args, _ = mock_objects.filter.call_args
+        self.assertEqual(called_args[0], expected_q)
+        mock_filtered.distinct.assert_called_once()
+        self.assertEqual(result, mock_filtered)

--- a/api/views.py
+++ b/api/views.py
@@ -12,7 +12,7 @@ from drf_yasg.utils import swagger_auto_schema
 from django.db.models import Q
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
-from django.db.models.functions import TruncSecond, TruncMinute, TruncHour, TruncDay, TruncMonth, TruncYear, Concat, Cast
+from django.db.models.functions import TruncSecond, TruncMinute, TruncHour, TruncDay, TruncMonth, TruncYear, Concat, Cast, Coalesce
 from django.db.models import Avg, F, Value, CharField, FloatField, DateTimeField, Func
 from django.utils.timezone import make_aware, utc, get_current_timezone
 
@@ -77,21 +77,13 @@ class PublicThingsViewSets(APIView):
         queryset = self.get_queryset(request.POST)
 
         q_objects = []
-        filters = {
-            "thing": lambda value: Q(id_thing__name = value),
-            "city": lambda value: Q(id_account__city = value),
-            "state": lambda value: Q(id_account__state = value),
-            "country": lambda value: Q(id_account__country = value),
-            "sensor": lambda value: Q(id_thing__in = self.filter_things_sensors(value)),
-            "thing_tag": lambda value: Q(id_thing__in = self.filter_things_tags(value)),
-            "sensor_tag": lambda value: Q(id_thing__in = self.filter_sensors_tags(value)),
-        }
+        filters = self.get_filters()
 
         for key, value in request.data.items():
             filter_func = filters.get(key)
             if filter_func:
                 q_objects.append(filter_func(value))
-        
+
         if q_objects:
             queryset = queryset.filter(*q_objects)
 
@@ -104,7 +96,18 @@ class PublicThingsViewSets(APIView):
             Q(accountsthings__id_account__status = True,
               accountsthings__id_account__id_plan__ispublic = True)
         ).distinct()
-   
+
+    def get_filters(self):
+        return {
+            "thing": lambda value: Q(name = value),
+            "city": lambda value: Q(accountsthings__id_account__city = value),
+            "state": lambda value: Q(accountsthings__id_account__state = value),
+            "country": lambda value: Q(accountsthings__id_account__country = value),
+            "sensor": lambda value: Q(id__in = self.filter_things_sensors(value)),
+            "thing_tag": lambda value: Q(id__in = self.filter_things_tags(value)),
+            "sensor_tag": lambda value: Q(id__in = self.filter_sensors_tags(value)),
+        }
+
     def filter_things_sensors(self, value):
         thing_ids = ThingsSensorsModel.objects.filter(id_sensor__name = value).values_list("id_thing_id", flat = True)
         return thing_ids
@@ -153,9 +156,11 @@ class DataViewSets(APIView):
             sensor = None
 
         if thing and sensor:
-            id_thingsensor = ThingsSensorsModel.objects.get(
+            id_thingsensor = ThingsSensorsModel.objects.annotate(
+                display_name = Coalesce('name', 'id_sensor__name')
+            ).get(
                 id_thing__uuid = thing,
-                id_sensor__name = sensor,
+                display_name = sensor,
             ).pk
 
         try:
@@ -181,10 +186,19 @@ class DataViewSets(APIView):
             "year": vwThingsSensorsData_YearModel,
         }
 
-        checkPublic = AccountsThingsModel.objects.filter(
-            id_thing__uuid = thing,
-            id_account__id_plan__ispublic = self.isPublic,
-        )
+        if self.isPublic:
+            checkPublic = ThingsModel.objects.filter(
+                uuid = thing,
+            ).filter(
+                Q(accountsthings__isnull = True) |
+                Q(accountsthings__id_account__status = True,
+                  accountsthings__id_account__id_plan__ispublic = True)
+            ).exists()
+        else:
+            checkPublic = AccountsThingsModel.objects.filter(
+                id_thing__uuid = thing,
+                id_account__id_plan__ispublic = False,
+            ).exists()
 
         if not checkPublic:
             return
@@ -323,21 +337,13 @@ class PrivateThingsViewSets(APIView):
         queryset = self.get_queryset(params = request.POST, user = request.user)
 
         q_objects = []
-        filters = {
-            "thing": lambda value: Q(id_thing__name = value),
-            "city": lambda value: Q(id_account__city = value),
-            "state": lambda value: Q(id_account__state = value),
-            "country": lambda value: Q(id_account__country = value),
-            "sensor": lambda value: Q(id_thing__in = self.filter_things_sensors(value)),
-            "thing_tag": lambda value: Q(id_thing__in = self.filter_things_tags(value)),
-            "sensor_tag": lambda value: Q(id_thing__in = self.filter_sensors_tags(value)),
-        }
+        filters = self.get_filters()
 
         for key, value in request.data.items():
             filter_func = filters.get(key)
             if filter_func:
                 q_objects.append(filter_func(value))
-        
+
         if q_objects:
             queryset = queryset.filter(*q_objects)
 
@@ -345,16 +351,25 @@ class PrivateThingsViewSets(APIView):
         return Response(serializer.data)
 
     def get_queryset(self, params, user):
-        Account = AccountsModel.objects.get(username = user)
-        account_id = Account.id
-        
-        return AccountsThingsModel.objects.filter(
-            id_account__status = True, 
-            id_account__id_plan__ispublic = False,
-            id_account = account_id,
+        account = AccountsModel.objects.get(username = user)
 
-        )
-   
+        return ThingsModel.objects.filter(
+            accountsthings__id_account__status = True,
+            accountsthings__id_account__id_plan__ispublic = False,
+            accountsthings__id_account = account,
+        ).distinct()
+
+    def get_filters(self):
+        return {
+            "thing": lambda value: Q(name = value),
+            "city": lambda value: Q(accountsthings__id_account__city = value),
+            "state": lambda value: Q(accountsthings__id_account__state = value),
+            "country": lambda value: Q(accountsthings__id_account__country = value),
+            "sensor": lambda value: Q(id__in = self.filter_things_sensors(value)),
+            "thing_tag": lambda value: Q(id__in = self.filter_things_tags(value)),
+            "sensor_tag": lambda value: Q(id__in = self.filter_sensors_tags(value)),
+        }
+
     def filter_things_sensors(self, value):
         thing_ids = ThingsSensorsModel.objects.filter(id_sensor__name = value).values_list("id_thing_id", flat = True)
         return thing_ids

--- a/api/views.py
+++ b/api/views.py
@@ -109,7 +109,9 @@ class PublicThingsViewSets(APIView):
         }
 
     def filter_things_sensors(self, value):
-        thing_ids = ThingsSensorsModel.objects.filter(id_sensor__name = value).values_list("id_thing_id", flat = True)
+        thing_ids = ThingsSensorsModel.objects.annotate(
+            display_name = Coalesce('name', 'id_sensor__name')
+        ).filter(display_name = value).values_list("id_thing_id", flat = True)
         return thing_ids
 
     def filter_things_tags(self, value):
@@ -371,7 +373,9 @@ class PrivateThingsViewSets(APIView):
         }
 
     def filter_things_sensors(self, value):
-        thing_ids = ThingsSensorsModel.objects.filter(id_sensor__name = value).values_list("id_thing_id", flat = True)
+        thing_ids = ThingsSensorsModel.objects.annotate(
+            display_name = Coalesce('name', 'id_sensor__name')
+        ).filter(display_name = value).values_list("id_thing_id", flat = True)
         return thing_ids
 
     def filter_things_tags(self, value):

--- a/api/views.py
+++ b/api/views.py
@@ -100,9 +100,9 @@ class PublicThingsViewSets(APIView):
     def get_filters(self):
         return {
             "thing": lambda value: Q(name = value),
-            "city": lambda value: Q(accountsthings__id_account__city = value),
+            "city": lambda value: Q(accountsthings__isnull = True) if value == "não registrado" else Q(accountsthings__id_account__city = value),
             "state": lambda value: Q(accountsthings__id_account__state = value),
-            "country": lambda value: Q(accountsthings__id_account__country = value),
+            "country": lambda value: Q(accountsthings__isnull = True) if value == "NR" else Q(accountsthings__id_account__country = value),
             "sensor": lambda value: Q(id__in = self.filter_things_sensors(value)),
             "thing_tag": lambda value: Q(id__in = self.filter_things_tags(value)),
             "sensor_tag": lambda value: Q(id__in = self.filter_sensors_tags(value)),
@@ -362,9 +362,9 @@ class PrivateThingsViewSets(APIView):
     def get_filters(self):
         return {
             "thing": lambda value: Q(name = value),
-            "city": lambda value: Q(accountsthings__id_account__city = value),
+            "city": lambda value: Q(accountsthings__isnull = True) if value == "não registrado" else Q(accountsthings__id_account__city = value),
             "state": lambda value: Q(accountsthings__id_account__state = value),
-            "country": lambda value: Q(accountsthings__id_account__country = value),
+            "country": lambda value: Q(accountsthings__isnull = True) if value == "NR" else Q(accountsthings__id_account__country = value),
             "sensor": lambda value: Q(id__in = self.filter_things_sensors(value)),
             "thing_tag": lambda value: Q(id__in = self.filter_things_tags(value)),
             "sensor_tag": lambda value: Q(id__in = self.filter_sensors_tags(value)),

--- a/api/views.py
+++ b/api/views.py
@@ -99,10 +99,11 @@ class PublicThingsViewSets(APIView):
         return Response(serializer.data)
 
     def get_queryset(self, params):
-        return AccountsThingsModel.objects.filter(
-            id_account__status = True, 
-            id_account__id_plan__ispublic = True,
-        )
+        return ThingsModel.objects.filter(
+            Q(accountsthings__isnull = True) |
+            Q(accountsthings__id_account__status = True,
+              accountsthings__id_account__id_plan__ispublic = True)
+        ).distinct()
    
     def filter_things_sensors(self, value):
         thing_ids = ThingsSensorsModel.objects.filter(id_sensor__name = value).values_list("id_thing_id", flat = True)

--- a/base/legacy_tables.py
+++ b/base/legacy_tables.py
@@ -139,6 +139,8 @@ class Thingssensors(models.Model):
     dt = models.DateTimeField()
     id_thing = models.ForeignKey(Things, models.DO_NOTHING, db_column='id_thing')
     id_sensor = models.ForeignKey(Sensors, models.DO_NOTHING, db_column='id_sensor')
+    name = models.CharField(max_length=30, blank=True, null=True)
+    channel = models.IntegerField()
 
     def __str__(self):
         return f"{self.id_thing} - {self.id_sensor}"

--- a/base/models.py
+++ b/base/models.py
@@ -149,3 +149,35 @@ class vwThingsSensorsData_DayModel(vwThingssensorsdata_day):
         verbose_name = "ThingSensorDatum_day"
         verbose_name_plural = 'ThingSensorsData_days'
         proxy = True
+
+
+from django.db.models.functions import Coalesce
+
+
+def get_thing_sensors_with_display_name(thing):
+    return ThingsSensorsModel.objects.filter(id_thing=thing).annotate(
+        display_name=Coalesce('name', 'id_sensor__name')
+    )
+
+
+def get_thing_account(thing):
+    return AccountsModel.objects.filter(
+        accountsthings__id_thing=thing
+    ).select_related('id_plan').first()
+
+
+def resolve_account_display(account):
+    if not account:
+        return {
+            "is_public": True,
+            "city": "não registrado",
+            "state": "",
+            "country": "NR",
+        }
+
+    return {
+        "is_public": account.id_plan.ispublic,
+        "city": account.city,
+        "state": account.state,
+        "country": account.country,
+    }

--- a/base/tests.py
+++ b/base/tests.py
@@ -1,6 +1,15 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.db.models.functions import Coalesce
 from django.test import SimpleTestCase
 
 from base.legacy_tables import Thingssensors
+from base.models import (
+    get_thing_account,
+    get_thing_sensors_with_display_name,
+    resolve_account_display,
+)
 
 
 class ThingssensorsSchemaTests(SimpleTestCase):
@@ -17,3 +26,65 @@ class ThingssensorsSchemaTests(SimpleTestCase):
 
         self.assertEqual(field.get_internal_type(), 'IntegerField')
         self.assertFalse(field.null)
+
+
+class GetThingSensorsWithDisplayNameTests(SimpleTestCase):
+    @patch('base.models.ThingsSensorsModel.objects')
+    def test_filters_by_thing_and_annotates_display_name(self, mock_objects):
+        mock_filtered = MagicMock()
+        mock_objects.filter.return_value = mock_filtered
+        mock_annotated = MagicMock()
+        mock_filtered.annotate.return_value = mock_annotated
+
+        result = get_thing_sensors_with_display_name(42)
+
+        mock_objects.filter.assert_called_once_with(id_thing=42)
+        annotate_kwargs = mock_filtered.annotate.call_args.kwargs
+        self.assertIsInstance(annotate_kwargs['display_name'], Coalesce)
+        self.assertEqual(result, mock_annotated)
+
+
+class GetThingAccountTests(SimpleTestCase):
+    @patch('base.models.AccountsModel.objects')
+    def test_filters_by_thing_and_returns_first_match(self, mock_objects):
+        mock_filtered = MagicMock()
+        mock_objects.filter.return_value = mock_filtered
+        mock_related = MagicMock()
+        mock_filtered.select_related.return_value = mock_related
+        expected_account = SimpleNamespace(id=7)
+        mock_related.first.return_value = expected_account
+
+        result = get_thing_account(99)
+
+        mock_objects.filter.assert_called_once_with(accountsthings__id_thing=99)
+        mock_filtered.select_related.assert_called_once_with('id_plan')
+        self.assertEqual(result, expected_account)
+
+
+class ResolveAccountDisplayTests(SimpleTestCase):
+    def test_returns_defaults_when_no_account(self):
+        result = resolve_account_display(None)
+
+        self.assertEqual(result, {
+            "is_public": True,
+            "city": "não registrado",
+            "state": "",
+            "country": "NR",
+        })
+
+    def test_returns_account_values_when_present(self):
+        account = SimpleNamespace(
+            id_plan=SimpleNamespace(ispublic=False),
+            city="Curitiba",
+            state="PR",
+            country="BR",
+        )
+
+        result = resolve_account_display(account)
+
+        self.assertEqual(result, {
+            "is_public": False,
+            "city": "Curitiba",
+            "state": "PR",
+            "country": "BR",
+        })

--- a/base/tests.py
+++ b/base/tests.py
@@ -1,3 +1,19 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
 
-# Create your tests here.
+from base.legacy_tables import Thingssensors
+
+
+class ThingssensorsSchemaTests(SimpleTestCase):
+    def test_name_field_is_nullable_charfield(self):
+        field = Thingssensors._meta.get_field('name')
+
+        self.assertEqual(field.get_internal_type(), 'CharField')
+        self.assertEqual(field.max_length, 30)
+        self.assertTrue(field.null)
+        self.assertTrue(field.blank)
+
+    def test_channel_field_is_required_integer(self):
+        field = Thingssensors._meta.get_field('channel')
+
+        self.assertEqual(field.get_internal_type(), 'IntegerField')
+        self.assertFalse(field.null)

--- a/docs/superpowers/plans/2026-07-06-thing-visibility-fallback.md
+++ b/docs/superpowers/plans/2026-07-06-thing-visibility-fallback.md
@@ -1,0 +1,715 @@
+# Thing Visibility Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `Thing` without an associated account becomes public by default and shows up in the public listing and detail page without crashing, and the displayed sensor name resolves to `thingssensors.name` with a fallback to `sensors.name`.
+
+**Architecture:** Two small query helpers and one presentation helper are added to `base/models.py` (domain layer) so the API serializer (`api/serializers.py`) and the web detail view (`sensors/views.py`) share the same account/sensor-name resolution instead of duplicating it. `api/views.py::PublicThingsViewSets` changes its queryset origin from the `accountsthings` join table to `Things` itself, so things without an account are no longer excluded.
+
+**Tech Stack:** Django 3.2 + Django REST Framework. Tests use `django.test.SimpleTestCase` (no real database — the shared Postgres tables are `managed = False` with no test migrations) plus `unittest.mock.patch` to stub ORM managers, run via `python manage.py test`.
+
+## Global Constraints
+
+- Source code (variables, functions, classes, comments, log/error messages) in English; only `/docs` content is Portuguese — spec: `docs/superpowers/specs/2026-07-06-thing-visibility-sensor-name-design.md`.
+- Never create or alter database schema from this repo — `thingssensors.name` (varchar(30) null) and `thingssensors.channel` (integer not null) already exist in the shared Postgres DB (owned by Sensoriando Core); only reflect them in `base/legacy_tables.py`.
+- No new dependencies — no `pytest`. Use `django.test` (`django.test.SimpleTestCase`), executed via `python manage.py test`.
+- Unit tests must not depend on real external services/DB — mock ORM managers with `unittest.mock.patch` (`docs/guidelines/testing.md`).
+- TDD Red → Green → Refactor: write the failing test before the production code, every step.
+- `PrivateThingsViewSets` is out of scope — it is already scoped to the logged-in user's own account and is unaffected.
+- Functional use of the `channel` column is out of scope — map it on the model only.
+- `thingssensors.name` is confirmed to always be `NULL` (never `""`) when not set — `Coalesce('name', 'id_sensor__name')` needs no extra empty-string handling.
+- Fallback values when a thing has no account: city = `"não registrado"`, state = `""`, country = `"NR"` (literal, no `pycountry` conversion attempted).
+- Never commit to `main`/`master`/`develop` directly; all work happens on `feat/thing-visibility-fallback` (already created off `develop`).
+
+---
+
+### Task 1: Map `thingssensors.name` and `thingssensors.channel` in the ORM
+
+**Files:**
+- Modify: `base/legacy_tables.py:138-148` (`Thingssensors` model)
+- Test: `base/tests.py`
+
+**Interfaces:**
+- Produces: `Thingssensors.name` (`CharField(max_length=30, blank=True, null=True)`), `Thingssensors.channel` (`IntegerField()`) — consumed by Task 2's `get_thing_sensors_with_display_name`.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the contents of `base/tests.py` with:
+
+```python
+from django.test import SimpleTestCase
+
+from base.legacy_tables import Thingssensors
+
+
+class ThingssensorsSchemaTests(SimpleTestCase):
+    def test_name_field_is_nullable_charfield(self):
+        field = Thingssensors._meta.get_field('name')
+
+        self.assertEqual(field.get_internal_type(), 'CharField')
+        self.assertEqual(field.max_length, 30)
+        self.assertTrue(field.null)
+        self.assertTrue(field.blank)
+
+    def test_channel_field_is_required_integer(self):
+        field = Thingssensors._meta.get_field('channel')
+
+        self.assertEqual(field.get_internal_type(), 'IntegerField')
+        self.assertFalse(field.null)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test base.tests.ThingssensorsSchemaTests -v 2`
+Expected: FAIL with `FieldDoesNotExist` (no field named 'name'/'channel' on Thingssensors).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `base/legacy_tables.py`, update the `Thingssensors` class:
+
+```python
+class Thingssensors(models.Model):
+    dt = models.DateTimeField()
+    id_thing = models.ForeignKey(Things, models.DO_NOTHING, db_column='id_thing')
+    id_sensor = models.ForeignKey(Sensors, models.DO_NOTHING, db_column='id_sensor')
+    name = models.CharField(max_length=30, blank=True, null=True)
+    channel = models.IntegerField()
+
+    def __str__(self):
+        return f"{self.id_thing} - {self.id_sensor}"
+
+    class Meta:
+        managed = False
+        db_table = 'thingssensors'
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python manage.py test base.tests.ThingssensorsSchemaTests -v 2`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base/legacy_tables.py base/tests.py
+git commit -m "feat: map thingssensors.name and thingssensors.channel columns"
+```
+
+---
+
+### Task 2: Add shared query helpers to `base/models.py`
+
+**Files:**
+- Modify: `base/models.py`
+- Test: `base/tests.py`
+
+**Interfaces:**
+- Consumes: `ThingsSensorsModel` (`base/legacy_tables.py::Thingssensors` proxy, now with `.name`/`.channel` from Task 1), `AccountsModel`.
+- Produces:
+  - `get_thing_sensors_with_display_name(thing) -> QuerySet[ThingsSensorsModel]` — each row annotated with `.display_name` (`Coalesce('name', 'id_sensor__name')`). Consumed by Task 4 (`api/serializers.py`) and Task 6 (`sensors/views.py`).
+  - `get_thing_account(thing) -> AccountsModel | None` — the account linked to `thing` (by id or instance) via `accountsthings`, or `None` if there is none. Consumed by Task 4 and Task 6.
+  - `resolve_account_display(account) -> dict` — `{"is_public": bool, "city": str, "state": str, "country": str}`, with fallback `{"is_public": True, "city": "não registrado", "state": "", "country": "NR"}` when `account` is `None`. Consumed by Task 6.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `base/tests.py`:
+
+```python
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.db.models.functions import Coalesce
+
+from base.models import (
+    get_thing_account,
+    get_thing_sensors_with_display_name,
+    resolve_account_display,
+)
+
+
+class GetThingSensorsWithDisplayNameTests(SimpleTestCase):
+    @patch('base.models.ThingsSensorsModel.objects')
+    def test_filters_by_thing_and_annotates_display_name(self, mock_objects):
+        mock_filtered = MagicMock()
+        mock_objects.filter.return_value = mock_filtered
+        mock_annotated = MagicMock()
+        mock_filtered.annotate.return_value = mock_annotated
+
+        result = get_thing_sensors_with_display_name(42)
+
+        mock_objects.filter.assert_called_once_with(id_thing=42)
+        annotate_kwargs = mock_filtered.annotate.call_args.kwargs
+        self.assertIsInstance(annotate_kwargs['display_name'], Coalesce)
+        self.assertEqual(result, mock_annotated)
+
+
+class GetThingAccountTests(SimpleTestCase):
+    @patch('base.models.AccountsModel.objects')
+    def test_filters_by_thing_and_returns_first_match(self, mock_objects):
+        mock_filtered = MagicMock()
+        mock_objects.filter.return_value = mock_filtered
+        mock_related = MagicMock()
+        mock_filtered.select_related.return_value = mock_related
+        expected_account = SimpleNamespace(id=7)
+        mock_related.first.return_value = expected_account
+
+        result = get_thing_account(99)
+
+        mock_objects.filter.assert_called_once_with(accountsthings__id_thing=99)
+        mock_filtered.select_related.assert_called_once_with('id_plan')
+        self.assertEqual(result, expected_account)
+
+
+class ResolveAccountDisplayTests(SimpleTestCase):
+    def test_returns_defaults_when_no_account(self):
+        result = resolve_account_display(None)
+
+        self.assertEqual(result, {
+            "is_public": True,
+            "city": "não registrado",
+            "state": "",
+            "country": "NR",
+        })
+
+    def test_returns_account_values_when_present(self):
+        account = SimpleNamespace(
+            id_plan=SimpleNamespace(ispublic=False),
+            city="Curitiba",
+            state="PR",
+            country="BR",
+        )
+
+        result = resolve_account_display(account)
+
+        self.assertEqual(result, {
+            "is_public": False,
+            "city": "Curitiba",
+            "state": "PR",
+            "country": "BR",
+        })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python manage.py test base.tests -v 2`
+Expected: FAIL with `ImportError: cannot import name 'get_thing_sensors_with_display_name' from 'base.models'` (function doesn't exist yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `base/models.py`, after the model class definitions (keep existing content above untouched, add at the end of the file):
+
+```python
+from django.db.models.functions import Coalesce
+
+
+def get_thing_sensors_with_display_name(thing):
+    return ThingsSensorsModel.objects.filter(id_thing=thing).annotate(
+        display_name=Coalesce('name', 'id_sensor__name')
+    )
+
+
+def get_thing_account(thing):
+    return AccountsModel.objects.filter(
+        accountsthings__id_thing=thing
+    ).select_related('id_plan').first()
+
+
+def resolve_account_display(account):
+    if not account:
+        return {
+            "is_public": True,
+            "city": "não registrado",
+            "state": "",
+            "country": "NR",
+        }
+
+    return {
+        "is_public": account.id_plan.ispublic,
+        "city": account.city,
+        "state": account.state,
+        "country": account.country,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python manage.py test base.tests -v 2`
+Expected: PASS (6 tests total: 2 from Task 1 + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base/models.py base/tests.py
+git commit -m "feat: add shared thing/account/sensor-name query helpers"
+```
+
+---
+
+### Task 3: Include things without an account in the public listing
+
+**Files:**
+- Modify: `api/views.py:101-105` (`PublicThingsViewSets.get_queryset`)
+- Test: `api/tests.py`
+
+**Interfaces:**
+- Consumes: `ThingsModel` (already imported in `api/views.py`), `Q` (already imported).
+- Produces: `PublicThingsViewSets.get_queryset(params)` now returns a `QuerySet[ThingsModel]` (previously `QuerySet[AccountsThingsModel]`) — Task 4's serializer must be adapted to receive `ThingsModel` instances.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the contents of `api/tests.py` with:
+
+```python
+from unittest.mock import MagicMock, patch
+
+from django.db.models import Q
+from django.test import SimpleTestCase
+
+from api.views import PublicThingsViewSets
+
+
+class PublicThingsGetQuerysetTests(SimpleTestCase):
+    @patch('api.views.ThingsModel.objects')
+    def test_includes_things_without_account_or_with_public_active_account(self, mock_objects):
+        mock_filtered = MagicMock()
+        mock_objects.filter.return_value = mock_filtered
+        mock_filtered.distinct.return_value = mock_filtered
+
+        view = PublicThingsViewSets()
+        result = view.get_queryset(params={})
+
+        expected_q = (
+            Q(accountsthings__isnull=True) |
+            Q(accountsthings__id_account__status=True,
+              accountsthings__id_account__id_plan__ispublic=True)
+        )
+        called_args, _ = mock_objects.filter.call_args
+        self.assertEqual(called_args[0], expected_q)
+        mock_filtered.distinct.assert_called_once()
+        self.assertEqual(result, mock_filtered)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test api.tests.PublicThingsGetQuerysetTests -v 2`
+Expected: FAIL — actual call args to `mock_objects.filter` don't match `expected_q` (current implementation still filters on `id_account__status`/`id_account__id_plan__ispublic` directly, with no `accountsthings__` prefix, and doesn't call `.distinct()`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `api/views.py`, replace `PublicThingsViewSets.get_queryset`:
+
+```python
+def get_queryset(self, params):
+    return ThingsModel.objects.filter(
+        Q(accountsthings__isnull = True) |
+        Q(accountsthings__id_account__status = True,
+          accountsthings__id_account__id_plan__ispublic = True)
+    ).distinct()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python manage.py test api.tests.PublicThingsGetQuerysetTests -v 2`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/views.py api/tests.py
+git commit -m "feat: include things without an account in the public listing"
+```
+
+---
+
+### Task 4: Adapt `DataThingsSerializer` to `Things` instances with account/sensor fallback
+
+**Files:**
+- Modify: `api/serializers.py:6-7` (imports), `api/serializers.py:48-86` (`DataThingsSerializer`)
+- Test: `api/tests.py`
+
+**Interfaces:**
+- Consumes: `get_thing_sensors_with_display_name(thing)`, `get_thing_account(thing)` (from Task 2, `base.models`), `ThingsModel` (Task 3 now feeds `DataThingsSerializer` instances of this type).
+- Produces: `DataThingsSerializer.get_account(obj)` returns `{"username": str|None, "city": str, "state": str, "country": str}` (fallback dict when no account). `DataThingsSerializer.get_sensors(obj)` returns `[{"id": int, "name": str}, ...]` using the resolved display name.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `api/tests.py`:
+
+```python
+from types import SimpleNamespace
+
+from api.serializers import DataThingsSerializer
+
+
+class DataThingsSerializerGetAccountTests(SimpleTestCase):
+    @patch('api.serializers.get_thing_account')
+    def test_returns_fallback_when_no_account(self, mock_get_thing_account):
+        mock_get_thing_account.return_value = None
+        obj = SimpleNamespace(id=1, name="thing-1", uuid="uuid-1")
+
+        result = DataThingsSerializer().get_account(obj)
+
+        mock_get_thing_account.assert_called_once_with(obj)
+        self.assertEqual(result, {
+            "username": None,
+            "city": "não registrado",
+            "state": "",
+            "country": "NR",
+        })
+
+    @patch('api.serializers.get_thing_account')
+    def test_returns_account_data_when_account_exists(self, mock_get_thing_account):
+        mock_get_thing_account.return_value = SimpleNamespace(
+            username="acc1", city="Curitiba", state="PR", country="BR"
+        )
+        obj = SimpleNamespace(id=1, name="thing-1", uuid="uuid-1")
+
+        result = DataThingsSerializer().get_account(obj)
+
+        self.assertEqual(result, {
+            "username": "acc1",
+            "city": "Curitiba",
+            "state": "PR",
+            "country": "BR",
+        })
+
+
+class DataThingsSerializerGetSensorsTests(SimpleTestCase):
+    @patch('api.serializers.get_thing_sensors_with_display_name')
+    def test_returns_id_and_resolved_display_name(self, mock_get_thing_sensors):
+        mock_get_thing_sensors.return_value = [
+            SimpleNamespace(id_sensor_id=10, display_name="Custom Name"),
+            SimpleNamespace(id_sensor_id=11, display_name="Temperature"),
+        ]
+        obj = SimpleNamespace(id=1)
+
+        result = DataThingsSerializer().get_sensors(obj)
+
+        mock_get_thing_sensors.assert_called_once_with(obj)
+        self.assertEqual(result, [
+            {"id": 10, "name": "Custom Name"},
+            {"id": 11, "name": "Temperature"},
+        ])
+
+
+class DataThingsSerializerThingFieldsTests(SimpleTestCase):
+    def test_get_thing_returns_name_from_obj(self):
+        obj = SimpleNamespace(name="thing-1", uuid="uuid-1")
+        self.assertEqual(DataThingsSerializer().get_thing(obj), "thing-1")
+
+    def test_get_uuid_returns_uuid_from_obj(self):
+        obj = SimpleNamespace(name="thing-1", uuid="uuid-1")
+        self.assertEqual(DataThingsSerializer().get_uuid(obj), "uuid-1")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python manage.py test api.tests -v 2`
+Expected: FAIL — `get_thing_account`/`get_thing_sensors_with_display_name` are not imported/used yet in `api/serializers.py`, and `get_thing`/`get_uuid`/`get_sensors` still read `obj.id_thing.*`, so calling with a plain `SimpleNamespace` thing raises `AttributeError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `api/serializers.py`, update the import block (lines 6-7):
+
+```python
+from base.models import ThingsModel, ThingsTagsModel, SensorsModel, ThingsSensorsTagsModel, \
+                        AccountsModel, AccountsThingsModel, ThingsSensorsModel, ThingsSensorsDataModel, \
+                        get_thing_sensors_with_display_name, get_thing_account
+```
+
+Replace `DataThingsSerializer` (lines 48-86):
+
+```python
+class DataThingsSerializer(serializers.ModelSerializer):
+    thing = serializers.SerializerMethodField()
+    uuid = serializers.SerializerMethodField()
+    account = serializers.SerializerMethodField()
+    sensors = serializers.SerializerMethodField()
+    lastupdate = serializers.SerializerMethodField()
+    thingtags = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ThingsModel
+        fields = ('thing', 'uuid', 'lastupdate', 'account', 'sensors', 'thingtags')
+
+    def get_thing(self, obj):
+        return obj.name
+
+    def get_uuid(self, obj):
+        return obj.uuid
+
+    def get_account(self, obj):
+        account = get_thing_account(obj)
+
+        if not account:
+            return {
+                "username": None,
+                "city": "não registrado",
+                "state": "",
+                "country": "NR",
+            }
+
+        return AccountSerializer(account).data
+
+    def get_sensors(self, obj):
+        thing_sensors = get_thing_sensors_with_display_name(obj)
+        return [
+            {"id": ts.id_sensor_id, "name": ts.display_name}
+            for ts in thing_sensors
+        ]
+
+    def get_thingtags(self, obj):
+        thing_tags = ThingsTagsModel.objects.filter(id_thing = obj)
+        return SensorSerializer(thing_tags, many = True).data
+
+    def get_lastupdate(self, obj):
+        thingsensor_ids = ThingsSensorsModel.objects.filter(id_thing = obj)
+        lastread = ThingsSensorsDataModel.objects.filter(id_thingsensor__in = thingsensor_ids).aggregate(Max('dtread'))['dtread__max']
+
+        return lastread.strftime("%d/%m/%Y %H:%M:%S") if lastread else "---"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python manage.py test api.tests -v 2`
+Expected: PASS (all `api.tests` cases, including Task 3's).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/serializers.py api/tests.py
+git commit -m "feat: resolve thing account and sensor display name with fallbacks"
+```
+
+---
+
+### Task 5: Make `overview/views.py::getCountry` tolerant of missing accounts
+
+**Files:**
+- Modify: `overview/views.py:36-44` (`getCountry`)
+- Test: `overview/tests.py`
+
+**Interfaces:**
+- Consumes: nothing new (still plain dicts from the `/things/` API response).
+- Produces: `getCountry(jsonResult)` no longer raises when an item's `"account"` is `None`/missing, and leaves the literal `"NR"` untouched instead of trying to convert it via `pycountry`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the contents of `overview/tests.py` with:
+
+```python
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from overview.views import getCountry
+
+
+class GetCountryTests(SimpleTestCase):
+    def test_returns_none_unchanged(self):
+        self.assertIsNone(getCountry(None))
+
+    def test_skips_items_without_account(self):
+        result = getCountry([{"thing": "t1", "account": None}])
+        self.assertEqual(result, [{"thing": "t1", "account": None}])
+
+    def test_keeps_nr_placeholder_without_converting(self):
+        result = getCountry([{"thing": "t1", "account": {"country": "NR"}}])
+        self.assertEqual(result[0]["account"]["country"], "NR")
+
+    @patch('overview.views.pycountry')
+    def test_converts_known_country_code(self, mock_pycountry):
+        mock_pycountry.countries.get.return_value = MagicMock(name="Brazil")
+        mock_pycountry.countries.get.return_value.name = "Brazil"
+
+        result = getCountry([{"thing": "t1", "account": {"country": "BR"}}])
+
+        mock_pycountry.countries.get.assert_called_once_with(alpha_2="BR")
+        self.assertEqual(result[0]["account"]["country"], "Brazil")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python manage.py test overview.tests -v 2`
+Expected: FAIL on `test_skips_items_without_account` with `TypeError: argument of type 'NoneType' is not iterable` (current `"country" in item["account"]` crashes when `account` is `None`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `overview/views.py`, replace `getCountry`:
+
+```python
+def getCountry(jsonResult):
+    if jsonResult:
+        for item in jsonResult:
+            account = item.get("account")
+
+            if not account:
+                continue
+
+            country_code = account.get("country")
+
+            if not country_code or country_code == "NR":
+                continue
+
+            country = pycountry.countries.get(alpha_2=country_code)
+
+            if country:
+                account["country"] = country.name
+
+    return jsonResult
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python manage.py test overview.tests -v 2`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add overview/views.py overview/tests.py
+git commit -m "fix: handle things without an account in getCountry"
+```
+
+---
+
+### Task 6: Fix the thing detail page for things without an account
+
+**Files:**
+- Modify: `sensors/views.py:1-11` (imports), `sensors/views.py:33-92` (`ThingDetails`)
+- Test: `sensors/tests.py`
+
+**Interfaces:**
+- Consumes: `get_thing_account(thing)`, `get_thing_sensors_with_display_name(thing)`, `resolve_account_display(account)` (Task 2, `base.models`).
+- Produces: `ThingDetails` no longer raises `DoesNotExist` (500) for a thing with no account; template context always has `city`/`state`/`country` populated (with fallback), and the public/private data endpoint choice defaults to public when there is no account.
+
+- [ ] **Step 1: Write the failing test**
+
+This task's new business logic (fallback resolution) is already covered by `ResolveAccountDisplayTests` in Task 2 — `ThingDetails` itself is a heavy view (cookies, `callAPI`, pandas) with no existing test harness, so this task adds one focused regression test instead of a full view test: that the view no longer calls `AccountsModel.objects.get` (which raises `DoesNotExist` for an accountless thing).
+
+Replace the contents of `sensors/tests.py` with:
+
+```python
+import inspect
+
+from django.test import SimpleTestCase
+
+from sensors import views
+
+
+class ThingDetailsAccountLookupTests(SimpleTestCase):
+    def test_does_not_use_unsafe_get_lookup_for_account(self):
+        source = inspect.getsource(views.ThingDetails)
+
+        self.assertNotIn("AccountsModel.objects.get(", source)
+        self.assertIn("get_thing_account(", source)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test sensors.tests -v 2`
+Expected: FAIL — `ThingDetails` still calls `AccountsModel.objects.get(accountsthings__id_thing = thing.id)`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `sensors/views.py`, update the import block (lines 1-11):
+
+```python
+from django.conf import settings
+from django.shortcuts import render, redirect
+from django.http import HttpResponse
+
+from base.views import callAPI
+from users.views import check_and_refresh_token
+from base.models import (
+    ThingsModel,
+    AccountsModel,
+    PlansModel,
+    ThingsSensorsModel,
+    ThingsTagsModel,
+    SensorsUnitsModel,
+    get_thing_account,
+    get_thing_sensors_with_display_name,
+    resolve_account_display,
+)
+
+from dateutil.parser import parse
+import pandas as pd
+import json
+```
+
+Then, inside `ThingDetails`, replace the data-loading block (originally lines 33-36):
+
+```python
+    thing = ThingsModel.objects.get(uuid = uuid)
+    thingtags = ThingsTagsModel.objects.filter(id_thing = thing.id)
+    thingssensors = get_thing_sensors_with_display_name(thing.id)
+    account = get_thing_account(thing.id)
+    account_display = resolve_account_display(account)
+```
+
+Replace the sensor-name line (originally line 45):
+
+```python
+        sensor = thingsensor.display_name
+```
+
+Replace the public/private branch (originally lines 92-104):
+
+```python
+        if account_display["is_public"]:
+            jsonResult = callAPI(
+                endpoint = "/data/detail/", \
+                data = jsonParams, \
+                method = "POST"
+            )
+        else:
+            jsonResult = callAPI(
+                endpoint = "/data/detail/private/", \
+                data = jsonParams, \
+                method = "POST", \
+                token = check_and_refresh_token()
+            )
+```
+
+Replace the context block (originally lines 139-149):
+
+```python
+    context = {
+        'thing': thing.name,
+        'thing_tags': tags,
+        'chart_file': 'chart.js',
+        'city': account_display["city"],
+        'state': account_display["state"],
+        'title': chartView,
+        'country': account_display["country"],
+        'sensors': sensors,
+
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python manage.py test sensors.tests -v 2`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `python manage.py test base api overview sensors -v 2`
+Expected: PASS — all tests from Tasks 1-6 (17 tests total: 2 + 4 + 1 + 5 + 4 + 1).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sensors/views.py sensors/tests.py
+git commit -m "fix: stop 500ing on thing detail page when there is no account"
+```
+
+- [ ] **Step 7: Manual verification**
+
+Since `ThingDetails` has no automated end-to-end coverage (no test DB for the `managed = False` tables, no existing request/response fixtures for `callAPI`), confirm behavior by hand once a real accountless thing exists in a dev database:
+
+1. Start the stack (see `run.sh`).
+2. Open `/thing/detail/<uuid>` for a `Thing` with no row in `accountsthings`.
+3. Confirm the page renders (no 500), city/state/country show the fallback values, and the sensor names shown match `thingssensors.name` when set, or the catalog `sensors.name` otherwise.
+4. Open `/` (public listing) and confirm the same thing now appears in the list.

--- a/docs/superpowers/specs/2026-07-06-thing-visibility-sensor-name-design.md
+++ b/docs/superpowers/specs/2026-07-06-thing-visibility-sensor-name-design.md
@@ -1,0 +1,204 @@
+# Spec: Things sem conta são públicos por padrão + nome do sensor por associação
+
+- Data: 2026-07-06
+- Branch: `feat/thing-visibility-fallback`
+- Status: aprovado para plano de implementação
+
+## Contexto
+
+Hoje um `Thing` só aparece nas listagens (pública ou privada) se existir uma
+linha correspondente em `accountsthings` (associação thing↔conta). A
+visibilidade pública/privada é herdada do plano da conta associada
+(`Plans.ispublic`). Um `Thing` cadastrado com seus sensores mas **sem**
+conta associada:
+
+- não aparece em nenhuma listagem (nem pública, nem privada);
+- quebra com erro 500 se acessado diretamente pela página de detalhe
+  (`sensors/views.py::ThingDetails`), pois o código busca a conta com
+  `.get()` (que levanta exceção se não encontrar linha).
+
+Além disso, o nome do sensor exibido em todas as telas vem sempre do
+catálogo (`sensors.name`), ignorando qualquer nome específico da associação
+thing↔sensor. O schema do banco (mantido pelo Sensoriando Core, fora deste
+repositório) já foi atualizado com duas colunas novas em `thingssensors`:
+
+- `name` (`varchar(30)`, nullable) — nome customizado da associação
+  thing↔sensor.
+- `channel` (`integer`, not null) — não utilizado nesta mudança, só precisa
+  ser mapeado no ORM para refletir o schema real.
+
+## Objetivo
+
+1. Um `Thing` sem conta associada passa a ser **público por padrão** e
+   aparece na listagem pública.
+2. O nome do sensor exibido passa a ser `thingssensors.name` quando
+   preenchido, com fallback para `sensors.name` quando estiver vazio/nulo.
+3. Quando não há conta associada, cidade/estado/país são exibidos com
+   fallback amigável em vez de branco ou erro.
+4. Corrigir o bug pré-existente de erro 500 na página de detalhe de um
+   `Thing` sem conta.
+
+## Decisões de design
+
+### 1. Schema (`base/legacy_tables.py`)
+
+Atualizar o model `Thingssensors` para refletir as colunas já existentes no
+banco (schema gerenciado pelo Sensoriando Core, `managed = False` — nenhuma
+migration é criada por este repositório):
+
+```python
+class Thingssensors(models.Model):
+    dt = models.DateTimeField()
+    id_thing = models.ForeignKey(Things, models.DO_NOTHING, db_column='id_thing')
+    id_sensor = models.ForeignKey(Sensors, models.DO_NOTHING, db_column='id_sensor')
+    name = models.CharField(max_length=30, blank=True, null=True)
+    channel = models.IntegerField()
+```
+
+`channel` é apenas mapeado; não há uso funcional nesta mudança.
+
+### 2. Nome do sensor (fallback via `Coalesce`)
+
+Decisão: a regra de fallback fica no webservice (não numa view do
+Sensoriando Core), pois:
+
+- é um cálculo trivial (`COALESCE` de duas colunas já unidas no mesmo
+  join que o serializer já faz);
+- hoje só o webservice lê o banco diretamente; a futura aplicação mobile
+  vai consumir a API do webservice, não o banco — então o valor já resolvido
+  chega pronto pra ela;
+- é lógica de apresentação, mesma categoria do fallback de cidade/estado/país
+  (item 4), que também fica no webservice.
+
+Implementação: usar `django.db.models.functions.Coalesce` na query, em vez
+de lógica condicional em Python:
+
+```python
+from django.db.models.functions import Coalesce
+from django.db.models import F
+
+ThingsSensorsModel.objects.filter(id_thing = obj.id_thing).annotate(
+    display_name = Coalesce('name', 'id_sensor__name')
+)
+```
+
+Pontos afetados:
+
+- `api/serializers.py::DataThingsSerializer.get_sensors` — passa a iterar
+  sobre `ThingsSensorsModel` anotado com `display_name`, em vez de re-buscar
+  em `SensorsModel` pelos ids.
+- `sensors/views.py::ThingDetails` (linha ~45) — troca
+  `thingsensor.id_sensor.name` por `thingsensor.name or thingsensor.id_sensor.name`
+  (ou usa o mesmo `annotate` com `Coalesce` na queryset de `thingssensors`
+  daquela view).
+
+### 3. Thing sem conta → público por padrão
+
+`api/views.py::PublicThingsViewSets.get_queryset` deixa de originar em
+`AccountsThingsModel` e passa a originar em `ThingsModel`, incluindo things
+sem nenhuma linha em `accountsthings` OU com conta de plano público e status
+ativo:
+
+```python
+from django.db.models import Q
+
+ThingsModel.objects.filter(
+    Q(accountsthings__isnull = True) |
+    Q(accountsthings__id_account__status = True,
+      accountsthings__id_account__id_plan__ispublic = True)
+)
+```
+
+Consequência: o objeto entregue ao `DataThingsSerializer` passa a ser uma
+instância de `ThingsModel` (não mais de `AccountsThingsModel`). O
+serializer precisa ser ajustado:
+
+- `get_thing`, `get_uuid` — passam a ler direto do próprio `obj` (era
+  `obj.id_thing.name` / `obj.id_thing.uuid`).
+- `get_account` — busca a conta via
+  `AccountsModel.objects.filter(accountsthings__id_thing = obj).first()`
+  (pode ser `None`).
+- `get_sensors`, `get_thingtags`, `get_lastupdate` — passam a filtrar por
+  `id_thing = obj` em vez de `id_thing = obj.id_thing`.
+
+`PrivateThingsViewSets` **não muda** — já é escopado à conta do usuário
+logado (`id_account = account_id`), então um thing sem conta nunca pode
+aparecer ali por definição.
+
+Os filtros de busca por `city`/`state`/`country` continuam usando
+`id_account__...`; um thing sem conta simplesmente não casa com esses
+filtros (não tem localização), o que é o comportamento esperado.
+
+### 4. Fallback de cidade/estado/país sem conta
+
+Em `DataThingsSerializer.get_account`, quando não há conta associada,
+retornar:
+
+```python
+{
+    "username": None,
+    "city": "não registrado",
+    "state": "",
+    "country": "NR",
+}
+```
+
+Em `overview/views.py::getCountry()`, pular a conversão via `pycountry`
+quando `account["country"] == "NR"` (ou quando `account` for `None`),
+evitando o `TypeError` atual de `"country" in None` e evitando chamar
+`pycountry.countries.get(alpha_2= "NR")` (que retornaria `None` e quebraria
+em `.name`).
+
+### 5. Correção do bug pré-existente na página de detalhe
+
+`sensors/views.py::ThingDetails` (linha ~36) troca:
+
+```python
+account = AccountsModel.objects.get(accountsthings__id_thing = thing.id)
+```
+
+por um lookup opcional:
+
+```python
+account = AccountsModel.objects.filter(accountsthings__id_thing = thing.id).first()
+```
+
+Com os mesmos fallbacks do item 4 aplicados ao contexto do template
+(`city`, `state`, `country`), e `account.id_plan.ispublic` tratado como
+`True` quando `account` é `None` (decide se a página busca dados via
+`/data/detail/` público ou `/data/detail/private/`).
+
+## Fora de escopo
+
+- Uso funcional da coluna `channel` (só mapeamento no model).
+- Qualquer mudança de schema no Sensoriando Core (já foi feita
+  externamente).
+- Alteração da listagem privada (`PrivateThingsViewSets`) — não afetada.
+- Exibição/remoção do país da UI — decisão revertida: país continua sendo
+  exibido normalmente, só com fallback `"NR"` quando não há conta.
+
+## Testes
+
+Não existe nenhuma suíte de testes real no projeto hoje (todos os
+`tests.py` são o scaffold vazio do Django). Serão os primeiros testes
+reais, cobrindo:
+
+- Thing sem conta aparece na listagem pública (`PublicThingsViewSets`);
+  thing com conta de plano privado não aparece.
+- Nome do sensor: `thingssensors.name` presente prevalece; em branco cai
+  para `sensors.name`.
+- Fallback de cidade (`"não registrado"`), estado (`""`) e país (`"NR"`)
+  quando não há conta associada.
+- Página de detalhe (`ThingDetails`) não retorna 500 para um thing sem
+  conta.
+
+## Riscos / pontos de atenção
+
+- Mudar a base do queryset de `AccountsThingsModel` para `ThingsModel` em
+  `PublicThingsViewSets` altera o shape do objeto passado ao serializer —
+  qualquer outro consumidor desse serializer (se houver) precisa ser
+  revisado.
+- `Coalesce` em campo `CharField(null=True, blank=True)`: strings vazias
+  (`""`) não são `NULL` — se `thingssensors.name` for gravado como `""` em
+  vez de `NULL`, o `Coalesce` não aplica o fallback. Validar com o
+  Sensoriando Core qual convenção é usada ao gravar essa coluna.

--- a/docs/superpowers/specs/2026-07-06-thing-visibility-sensor-name-design.md
+++ b/docs/superpowers/specs/2026-07-06-thing-visibility-sensor-name-design.md
@@ -199,6 +199,7 @@ reais, cobrindo:
   qualquer outro consumidor desse serializer (se houver) precisa ser
   revisado.
 - `Coalesce` em campo `CharField(null=True, blank=True)`: strings vazias
-  (`""`) não são `NULL` — se `thingssensors.name` for gravado como `""` em
-  vez de `NULL`, o `Coalesce` não aplica o fallback. Validar com o
-  Sensoriando Core qual convenção é usada ao gravar essa coluna.
+  (`""`) não são `NULL`, então normalmente seria preciso validar a convenção
+  de gravação. Confirmado com o time: o Sensoriando Core nunca grava `""` em
+  `thingssensors.name`, sempre `NULL` quando não informado — `Coalesce` pode
+  ser usado diretamente, sem tratamento extra para string vazia.

--- a/overview/tests.py
+++ b/overview/tests.py
@@ -1,8 +1,10 @@
+import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
-from overview.views import getCountry
+from overview.views import getCountry, readCookie
 
 
 class GetCountryTests(SimpleTestCase):
@@ -26,3 +28,39 @@ class GetCountryTests(SimpleTestCase):
 
         mock_pycountry.countries.get.assert_called_once_with(alpha_2="BR")
         self.assertEqual(result[0]["account"]["country"], "Brazil")
+
+
+def _request_with_cookie(payload):
+    return SimpleNamespace(COOKIES={"setFilterHome": json.dumps(payload)})
+
+
+class ReadCookieTests(SimpleTestCase):
+    def test_returns_none_without_cookie(self):
+        request = SimpleNamespace(COOKIES={})
+        self.assertIsNone(readCookie(request))
+
+    def test_keeps_nr_placeholder_without_crashing(self):
+        request = _request_with_cookie({"country": "NR"})
+
+        result = readCookie(request)
+
+        self.assertEqual(result["country"], "NR")
+
+    @patch('overview.views.pycountry')
+    def test_converts_recognized_country_name_to_alpha2(self, mock_pycountry):
+        mock_pycountry.countries.get.return_value = SimpleNamespace(alpha_2="BR")
+        request = _request_with_cookie({"country": "Brazil"})
+
+        result = readCookie(request)
+
+        mock_pycountry.countries.get.assert_called_once_with(name="Brazil")
+        self.assertEqual(result["country"], "BR")
+
+    @patch('overview.views.pycountry')
+    def test_unrecognized_country_name_does_not_crash(self, mock_pycountry):
+        mock_pycountry.countries.get.return_value = None
+        request = _request_with_cookie({"country": "Nonexistentland"})
+
+        result = readCookie(request)
+
+        self.assertEqual(result["country"], "Nonexistentland")

--- a/overview/tests.py
+++ b/overview/tests.py
@@ -1,3 +1,28 @@
-from django.test import TestCase
+from unittest.mock import MagicMock, patch
 
-# Create your tests here.
+from django.test import SimpleTestCase
+
+from overview.views import getCountry
+
+
+class GetCountryTests(SimpleTestCase):
+    def test_returns_none_unchanged(self):
+        self.assertIsNone(getCountry(None))
+
+    def test_skips_items_without_account(self):
+        result = getCountry([{"thing": "t1", "account": None}])
+        self.assertEqual(result, [{"thing": "t1", "account": None}])
+
+    def test_keeps_nr_placeholder_without_converting(self):
+        result = getCountry([{"thing": "t1", "account": {"country": "NR"}}])
+        self.assertEqual(result[0]["account"]["country"], "NR")
+
+    @patch('overview.views.pycountry')
+    def test_converts_known_country_code(self, mock_pycountry):
+        mock_pycountry.countries.get.return_value = MagicMock(name="Brazil")
+        mock_pycountry.countries.get.return_value.name = "Brazil"
+
+        result = getCountry([{"thing": "t1", "account": {"country": "BR"}}])
+
+        mock_pycountry.countries.get.assert_called_once_with(alpha_2="BR")
+        self.assertEqual(result[0]["account"]["country"], "Brazil")

--- a/overview/views.py
+++ b/overview/views.py
@@ -37,10 +37,20 @@ def readCookie(request):
 def getCountry(jsonResult):
     if jsonResult:
         for item in jsonResult:
-            if "country" in item["account"]:
-                country_code = item["account"]["country"]
-                country_name = pycountry.countries.get(alpha_2=country_code).name
-                item["account"]["country"] = country_name
+            account = item.get("account")
+
+            if not account:
+                continue
+
+            country_code = account.get("country")
+
+            if not country_code or country_code == "NR":
+                continue
+
+            country = pycountry.countries.get(alpha_2=country_code)
+
+            if country:
+                account["country"] = country.name
 
     return jsonResult
 

--- a/overview/views.py
+++ b/overview/views.py
@@ -26,9 +26,11 @@ def readCookie(request):
     if cookieValue:
         jsonCookie = json.loads(cookieValue)
 
-        if "country" in jsonCookie:
+        if "country" in jsonCookie and jsonCookie["country"] != "NR":
             country = pycountry.countries.get(name=jsonCookie["country"])
-            jsonCookie["country"] = country.alpha_2 
+
+            if country:
+                jsonCookie["country"] = country.alpha_2
     else:
         jsonCookie = None
 

--- a/sensors/tests.py
+++ b/sensors/tests.py
@@ -1,3 +1,13 @@
-from django.test import TestCase
+import inspect
 
-# Create your tests here.
+from django.test import SimpleTestCase
+
+from sensors import views
+
+
+class ThingDetailsAccountLookupTests(SimpleTestCase):
+    def test_does_not_use_unsafe_get_lookup_for_account(self):
+        source = inspect.getsource(views.ThingDetails)
+
+        self.assertNotIn("AccountsModel.objects.get(", source)
+        self.assertIn("get_thing_account(", source)

--- a/sensors/views.py
+++ b/sensors/views.py
@@ -4,7 +4,17 @@ from django.http import HttpResponse
 
 from base.views import callAPI
 from users.views import check_and_refresh_token
-from base.models import ThingsModel, AccountsModel, PlansModel, ThingsSensorsModel, ThingsTagsModel, SensorsUnitsModel
+from base.models import (
+    ThingsModel,
+    AccountsModel,
+    PlansModel,
+    ThingsSensorsModel,
+    ThingsTagsModel,
+    SensorsUnitsModel,
+    get_thing_account,
+    get_thing_sensors_with_display_name,
+    resolve_account_display,
+)
 
 from dateutil.parser import parse
 import pandas as pd
@@ -32,9 +42,10 @@ def ThingDetails(request, uuid = None):
     # Get data
     thing = ThingsModel.objects.get(uuid = uuid)
     thingtags = ThingsTagsModel.objects.filter(id_thing = thing.id)
-    thingssensors = ThingsSensorsModel.objects.filter(id_thing = thing.id)
-    account = AccountsModel.objects.get(accountsthings__id_thing = thing.id)
- 
+    thingssensors = get_thing_sensors_with_display_name(thing.id)
+    account = get_thing_account(thing.id)
+    account_display = resolve_account_display(account)
+
     tags = []
     for tag in thingtags:
         tags.append(tag.name)
@@ -42,7 +53,7 @@ def ThingDetails(request, uuid = None):
     sensors = []
     for thingsensor in thingssensors:
         id_sensor = thingsensor.id_sensor_id
-        sensor = thingsensor.id_sensor.name
+        sensor = thingsensor.display_name
         sensor_unit = SensorsUnitsModel.objects.get(isdefault = True, id_sensor = id_sensor)
 
         defaults["chartunit"] = sensor_unit
@@ -89,7 +100,7 @@ def ThingDetails(request, uuid = None):
 
         }
     
-        if account.id_plan.ispublic:
+        if account_display["is_public"]:
             jsonResult = callAPI(
                 endpoint = "/data/detail/", \
                 data = jsonParams, \
@@ -140,10 +151,10 @@ def ThingDetails(request, uuid = None):
         'thing': thing.name,
         'thing_tags': tags,
         'chart_file': 'chart.js',
-        'city': account.city,
-        'state': account.state,
+        'city': account_display["city"],
+        'state': account_display["state"],
         'title': chartView,
-        'country': account.country,
+        'country': account_display["country"],
         'sensors': sensors,
 
     }

--- a/sensors/views.py
+++ b/sensors/views.py
@@ -6,9 +6,6 @@ from base.views import callAPI
 from users.views import check_and_refresh_token
 from base.models import (
     ThingsModel,
-    AccountsModel,
-    PlansModel,
-    ThingsSensorsModel,
     ThingsTagsModel,
     SensorsUnitsModel,
     get_thing_account,


### PR DESCRIPTION
## Resumo
- Um `Thing` sem conta associada agora é público por padrão e aparece na listagem pública, ao invés de ficar invisível (`api/views.py::PublicThingsViewSets`).
- O nome do sensor exibido resolve para `thingssensors.name` quando preenchido, com fallback para `sensors.name` (via `Coalesce`), tanto na API quanto na página de detalhe.
- Cidade/estado/país ganham fallback de apresentação quando não há conta (`"não registrado"` / `""` / `"NR"`).
- Corrige bug pré-existente de erro 500 na página de detalhe do thing para things sem conta.
- Corrige regressões encontradas na revisão final: `PrivateThingsViewSets` (que compartilha o serializer reescrito), os filtros de busca (cidade/estado/país/sensor/tags) em ambas as listagens, e a resolução de sensor no endpoint de dados do gráfico (`DataViewSets`), que também passa a liberar dados para things sem conta.

### Correções adicionais (encontradas em verificação manual pós-revisão)
- Filtro por cidade/país: clicar em "não registrado"/"NR" não retornava nenhum thing, pois o filtro comparava esses textos de apresentação literalmente contra `Accounts.city`/`Accounts.country`. Agora eles casam corretamente com things sem conta (`Q(accountsthings__isnull=True)`), em ambas as listagens.
- `overview/views.py::readCookie`: quebrava com `AttributeError` ao tentar converter o placeholder `"NR"` de volta para um código de país via `pycountry`. Agora o literal `"NR"` é preservado sem conversão, e qualquer nome de país não reconhecido também deixou de derrubar a página.
- Filtro por sensor: clicar num sensor com nome customizado (`thingssensors.name`) não retornava nenhum thing, pois o filtro ainda comparava contra o nome de catálogo (`sensors.name`). Agora casa pelo mesmo nome resolvido (`Coalesce`) exibido na tela, em ambas as listagens.

Spec: `docs/superpowers/specs/2026-07-06-thing-visibility-sensor-name-design.md`
Plano: `docs/superpowers/plans/2026-07-06-thing-visibility-fallback.md`

Schema: `thingssensors.name` e `thingssensors.channel` já existem no banco compartilhado (schema de responsabilidade do Sensoriando Core); este PR só reflete essas colunas no ORM (`managed = False`, nenhuma migration criada aqui).

## Plano de testes
- [x] 35 testes automatizados (primeira suíte real do projeto), rodando via `docker compose exec webservice python manage.py test base api overview sensors -v 2` — 35/35 passando.
- [x] Revisão de cada uma das 6 tasks do plano (spec compliance + qualidade) aprovada individualmente.
- [x] Revisão final de branch (Opus) encontrou 2 regressões críticas + 1 importante entre tasks; corrigidas e re-revisadas — aprovado para merge.
- [x] Verificação manual: uso real da listagem pública encontrou os 3 bugs de filtro acima, corrigidos com TDD (RED confirmado reproduzindo o erro antes do fix).
- [ ] Nuance em aberto, tratada em issue separada (#61): dropdown de busca continua filtrando por tipo de sensor (catálogo); clique no nome do sensor no card passará a filtrar pelo tipo também (`id_sensor`), em vez do nome resolvido/customizado. Não tratada neste PR.
