### PR TITLE
feat: autenticacao via Cognito com OTP por e-mail

### DIFF
--- a/docs/guidelines/architecture.md
+++ b/docs/guidelines/architecture.md
@@ -13,6 +13,8 @@ pelo Sensoriando Core via MQTT.
 Navegador → CloudFront → S3 (bundle estático)
     │
     └── HTTPS → API Gateway → Lambdas → PostgreSQL (Neon)
+                     │            └────→ Cognito (identidade)
+                     └── authorizer valida o ID token
 ```
 
 ---
@@ -24,8 +26,8 @@ web/src/
   api/          client.ts     → única camada que conhece fetch; normaliza erro em ApiError
                 endpoints.ts  → uma função por rota; marca as rotas ainda inexistentes
                 types.ts      → formas dos dados da API
-  auth/         session.ts    → portão de conveniência em localStorage
-                AuthGate.tsx  → redireciona rotas privadas para o login
+  auth/         session.ts    → refresh token no localStorage, ID token em memória
+                AuthGate.tsx  → renova antes de renderizar; redireciona quem não tem sessão
   lib/          filters.ts    → filtros ↔ query string
                 prefs.ts      → período e tipo de gráfico em localStorage
                 format.ts     → rótulos de gráfico por período
@@ -51,6 +53,10 @@ scripts/        resolve_api_url.py    → descobre a URL da API no CloudFormatio
 2. No navegador, cada view chama `useApi` com uma função de `api/endpoints.ts`.
 3. `api/client.ts` faz a requisição e converte qualquer falha em `ApiError`.
 4. A view renderiza um de três estados: carregando, erro ou vazio.
+5. Nas rotas privadas, `client.ts` injeta o ID token (`Authorization: Bearer`) e,
+   num 401, renova o token exatamente uma vez antes de repetir a requisição — a
+   renovação é compartilhada entre chamadas concorrentes, então várias telas
+   abrindo juntas disparam uma única troca de token.
 
 Rotas que a API ainda não expõe estão marcadas em `endpoints.ts`: um 404 vindo
 delas vira a mensagem `Recurso ainda não disponível na API`, distinta de um erro

--- a/docs/guidelines/coding-standards.md
+++ b/docs/guidelines/coding-standards.md
@@ -76,5 +76,9 @@ Nenhuma tela monta URL na mão: toda chamada passa por `api/endpoints.ts`.
 - Não fazer rede a partir de componentes de apresentação.
 - Não converter nem arredondar valores de sensor no front-end — a API é quem
   entrega o valor pronto (decisão D4 do documento de design).
-- Não tratar o portão de sessão como controle de acesso: ele não protege dado
-  nenhum (decisão D2).
+- Não persistir o ID token: ele vive só em memória (`auth/session.ts`) e some
+  ao fechar a aba. Só o refresh token vai para o `localStorage`. Ver a decisão
+  D3 do spec de autenticação.
+- Não tratar `AuthGate` como decisão única: uma sessão já aprovada pode
+  expirar no meio do uso, e o gate precisa reagir a isso (`onSessionExpired`
+  em `auth/session.ts`), não só decidir uma vez no mount.

--- a/docs/guidelines/stacks.md
+++ b/docs/guidelines/stacks.md
@@ -52,6 +52,7 @@ repositório.
 - `vite`, `@vitejs/plugin-react`, `typescript`, `vitest`, `@types/*`
 - `@testing-library/react` — 16.3.2 (testes de componente)
 - `@testing-library/dom` — 10.4.1 (dependência dos testes de componente)
+- `@testing-library/user-event` — 14.6.5 (interações de usuário nos testes)
 - `jsdom` — 30.0.1 (ambiente de DOM para testes de componente)
 
 ### Infraestrutura (`infra/requirements.txt`, versões fixadas)

--- a/docs/guidelines/stacks.md
+++ b/docs/guidelines/stacks.md
@@ -50,6 +50,9 @@ repositório.
 ### Desenvolvimento
 
 - `vite`, `@vitejs/plugin-react`, `typescript`, `vitest`, `@types/*`
+- `@testing-library/react` — 16.3.2 (testes de componente)
+- `@testing-library/dom` — 10.4.1 (dependência dos testes de componente)
+- `jsdom` — 30.0.1 (ambiente de DOM para testes de componente)
 
 ### Infraestrutura (`infra/requirements.txt`, versões fixadas)
 

--- a/docs/guidelines/stacks.md
+++ b/docs/guidelines/stacks.md
@@ -30,6 +30,8 @@ repositório.
 - **CloudFront** — distribuição
 - **CloudFormation** — origem da URL da API, lida no build
 - **SSM Parameter Store** — mecanismo de configuração (sem chaves declaradas hoje)
+- **Cognito** — identidade dos usuários. Alcançado **pela API**, nunca pelo
+  navegador: o SPA não conhece pool id nem client id.
 
 ---
 
@@ -46,6 +48,8 @@ repositório.
 - `react`, `react-dom` — 18.3
 - `react-router-dom` — 7.1
 - `chart.js` — 4.4
+- Nenhuma biblioteca de autenticação. Como a API intermedia o Cognito, o SPA não
+  precisa de `oidc-client-ts` nem `amazon-cognito-identity-js`.
 
 ### Desenvolvimento
 
@@ -75,7 +79,8 @@ repositório.
 
 ```
 web/src/api/         cliente HTTP, endpoints tipados e formas dos dados
-web/src/auth/        portão de sessão
+web/src/auth/        sessão (refresh token em localStorage, ID token em memória) e
+                     portão que renova o token antes de renderizar
 web/src/lib/         funções puras (filtros, preferências, formatação, país)
 web/src/components/  apresentação, sem rede
 web/src/views/       telas, que buscam dados e compõem componentes

--- a/docs/superpowers/handoffs/2026-08-19-autenticacao-cognito-otp.md
+++ b/docs/superpowers/handoffs/2026-08-19-autenticacao-cognito-otp.md
@@ -1,0 +1,231 @@
+# Handoff — Autenticação via Cognito com OTP por e-mail
+
+**Para:** o agente que vai implementar
+**Data:** 2026-08-19
+**Repositório:** `/mnt/storage/git/sensoriando_webservice`, branch `feat/autenticacao-cognito-otp`
+
+---
+
+## 1. O que você vai fazer
+
+Trocar o portão de sessão falso deste SPA por autenticação real **sem senha**: o
+usuário informa o e-mail, recebe um código de uso único e o digita. E ligar as
+telas privadas às rotas de conta da API.
+
+O SPA continua um bundle estático que **só consome a API**. Ele não fala com o
+Cognito, não carrega biblioteca de autenticação e não conhece pool id nem client
+id — quem conversa com o Cognito é o `SENSORIANDO_API`.
+
+O trabalho já está inteiramente especificado. Dois documentos carregam tudo:
+
+| Documento | Papel |
+|---|---|
+| `docs/superpowers/specs/2026-08-19-autenticacao-cognito-otp-design.md` | As sete decisões, com a razão de cada uma, e o que ficou fora |
+| `docs/superpowers/plans/2026-08-19-autenticacao-cognito-otp.md` | 10 tasks, com o código real de cada arquivo |
+
+Leia os dois antes de escrever a primeira linha.
+
+---
+
+## 2. Como executar
+
+**Use a skill `superpowers:subagent-driven-development`.** Invoque-a antes de
+começar e siga o que ela mandar.
+
+O regime é: um subagente novo por task, revisão em duas etapas entre uma task e
+a seguinte. Cada task termina num entregável testável de forma independente e
+declara, num bloco `Interfaces`, o que consome das anteriores e o que produz
+para as seguintes — um subagente que só enxerga a própria task trabalha a partir
+desse bloco.
+
+Execute as tasks **em ordem**. As dependências entre elas são reais: a Task 3
+quebra a compilação de `SignUp.tsx` e `Account.tsx` de propósito, e só as Tasks
+6 e 9 fecham os tipos de novo.
+
+### Branch, e nada de worktree
+
+Trabalhe **direto no diretório do repositório**, na branch
+`feat/autenticacao-cognito-otp`, que já existe e já está com o commit dos
+documentos. **Não crie worktree.** Se alguma skill sugerir isolar o trabalho num
+worktree, ignore essa parte: a instrução do dono do repositório é trabalhar na
+branch mesmo.
+
+```bash
+cd /mnt/storage/git/sensoriando_webservice
+git branch --show-current   # deve responder: feat/autenticacao-cognito-otp
+```
+
+`AGENTS.md` proíbe commit em `main` e em `develop`. Commite a cada task, com as
+mensagens que o plano já traz.
+
+---
+
+## 3. Estado do repositório agora
+
+Nada foi implementado. O que existe é documentação:
+
+```
+docs/superpowers/specs/2026-08-19-autenticacao-cognito-otp-design.md   ← o design
+docs/superpowers/plans/2026-08-19-autenticacao-cognito-otp.md          ← o plano
+docs/superpowers/handoffs/2026-08-19-autenticacao-cognito-otp.md       ← este arquivo
+```
+
+O resto é o SPA em React sobre Vite, publicado em S3 + CloudFront por uma stack
+CDK em `infra/`.
+
+| Comando | O quê |
+|---|---|
+| `cd web && npm test` | Toda a suíte do SPA (vitest) |
+| `cd web && npm run build` | `tsc -b` e o bundle — é aqui que erro de tipo aparece |
+| `make test` | SPA e síntese do CDK |
+
+Os testes ficam **ao lado do módulo**, como `client.test.ts` ao lado de
+`client.ts`. Siga isso.
+
+---
+
+## 4. O que a exploração já apurou
+
+São fatos verificados no código, não suposições.
+
+### O portão atual é assumidamente decorativo
+
+`web/src/auth/session.ts` diz no próprio docstring: *"A convenience gate, not a
+security boundary […] the gate only keeps the private screens out of the way
+until real authentication (Cognito) lands."* Este trabalho é o "until".
+
+Consequência prática: **não há usuário real para migrar.** Uma sessão antiga no
+`localStorage` tem `username` e nenhum refresh token; a Task 1 a trata como
+`null` de propósito, e o usuário simplesmente entra de novo.
+
+### Nenhuma biblioteca nova de runtime
+
+Como a API intermedia o Cognito, o SPA **não precisa** de `oidc-client-ts` nem
+`amazon-cognito-identity-js`. O `docs/guidelines/stacks.md` fica intacto na
+seção de bibliotecas permitidas.
+
+As Tasks 4 e 5 instalam `@testing-library/*` e `jsdom` como **devDependencies** —
+são os primeiros testes de componente do repositório. Isso é permitido e o plano
+manda registrar no `stacks.md`, na seção de Desenvolvimento, onde `vitest` e
+`@types/*` já estão.
+
+### O build não muda
+
+`vite.config.ts` já descobre a URL da API no CloudFormation via
+`scripts/resolve_api_url.py`. Pool id e client id **não** são injetados, porque o
+navegador nunca os usa.
+
+### Os tipos que o `endpoints.ts` declara hoje não batem com o banco
+
+`PrivateAccount` tem `first_name`/`last_name`; o Odoo tem um `name` só, e
+`res.partner.name` é um campo único. `AccountInput` tem `password`; não há senha
+nesta plataforma. A Task 3 corrige os dois.
+
+### `web_stack.py` invalida o CloudFront
+
+`distribution_paths=["/*"]` no `BucketDeployment`: o bundle novo propaga assim
+que o deploy termina, sem espera de TTL.
+
+---
+
+## 5. As sete decisões, em uma linha cada
+
+| # | Decisão |
+|---|---|
+| D1 | Nenhuma biblioteca de runtime nova |
+| D2 | Nada de novo no build: sem pool id, sem client id |
+| D3 | ID token só em memória; refresh token no `localStorage` |
+| D4 | Sessão de 30 dias, sem deslizar |
+| D5 | Renovação com promessa compartilhada |
+| D6 | `name` único, sem `first_name`/`last_name` |
+| D7 | Unidade preferida vai para o `localStorage` |
+
+A razão de cada uma está na seção 3 do spec.
+
+---
+
+## 6. A dependência do outro repositório
+
+**Duas tasks aqui dependem de um resultado que só a AWS real dá.**
+
+O plano do `SENSORIANDO_API` tem, ao fim da fase 1 dele, uma verificação
+obrigatória: publicar e rodar um cadastro e um login de ponta a ponta. Duas das
+três coisas que ela valida decidem o formato de módulos deste repositório:
+
+- **Se `POST /accounts/confirm` não devolver tokens**, o cadastro não entra
+  logado, e a Task 6 (`SignUp.tsx`) tem que mandar o usuário ao login.
+- **Se o `SECRET_HASH` sobre o e-mail não for aceito**, `login()` e `verifyOtp()`
+  mudam de assinatura na Task 3, e a tela da Task 5 junto.
+
+**Confirme o resultado dessa verificação antes de começar as Tasks 3, 5 e 6.**
+As Tasks 1 e 2 (`session.ts` e `client.ts`) não dependem dela e podem começar a
+qualquer momento.
+
+---
+
+## 7. Checkpoints
+
+```bash
+# Fase 1 (após a Task 7)
+cd web && npm test && npm run build
+grep -rn "getIdToken\|setIdToken" src --include=*.tsx   # nada fora de auth/ e api/
+
+# Fase 3 (após a Task 10)
+cd web && npm test && npm run build
+grep -rn "first_name\|savePreferredUnit\|password" src   # nada
+grep -rn "portão de conveniência\|convenience gate" ../docs ../web/src   # nada
+```
+
+O `npm run build` importa tanto quanto o `npm test`: é o `tsc -b` que pega os
+tipos trocados na Task 3 e não fechados até a Task 9.
+
+---
+
+## 8. Quando considerar pronto
+
+- `npm test` e `npm run build` passam.
+- Um F5 numa tela privada **não** desloga: o `AuthGate` renova antes de
+  renderizar.
+- O `localStorage` do navegador, após login, contém `username` e
+  `refreshToken` — e **nenhum ID token**. Confira no DevTools.
+- Cinco telas privadas carregando ao mesmo tempo disparam **uma** chamada a
+  `/auth/refresh`, não cinco. O teste de renovação concorrente da Task 2 cobre
+  isso, mas vale ver na aba Network.
+- A aba Perfil mostra um campo Nome, nenhum Sobrenome, e o E-mail somente
+  leitura.
+
+---
+
+## 9. O que não fazer
+
+- **Não** acrescente biblioteca de runtime. Em especial nenhuma de autenticação:
+  se você sentiu falta de uma, o desenho foi mal entendido — o SPA não fala com
+  o Cognito.
+- **Não** persista o ID token no `localStorage` nem em cookie. Ele vive em
+  memória, e isso é a decisão D3.
+- **Não** implemente `savePreferredUnit` contra a API. Não existe tabela para
+  isso; a preferência vai para `lib/prefs.ts` (D7).
+- **Não** faça a tela de login tentar descobrir se o e-mail existe antes de
+  pedir o código. A API responde igual para os dois casos de propósito.
+- **Não** faça componentes de `components/` buscarem dados. Quem busca é
+  `views/` (`docs/guidelines/architecture.md`).
+- **Não** use `eval()` nem `new Function()`.
+- **Não** crie worktree. Trabalhe na branch.
+- **Não** commite em `main` nem em `develop`, e **não** faça merge nem abra PR
+  por conta própria — a decisão é do usuário (`AGENTS.md`).
+
+---
+
+## 10. Ao terminar
+
+Relate:
+
+1. O resultado dos checkpoints da seção 7, com a saída real dos comandos.
+2. As versões exatas das devDependencies instaladas nas Tasks 4 e 5, e a
+   confirmação de que entraram no `stacks.md`.
+3. Qualquer desvio do plano, com a razão — em especial se a verificação do outro
+   repositório (seção 6) tiver obrigado a mudar as Tasks 3, 5 ou 6.
+4. O que ficou pendente: a unidade preferida por conta continua local, e voltará
+   a ser assunto se um dia o `SENSORIANDO_CORE` ganhar a tabela.
+
+Se algo no plano estiver errado ou impossível, **diga em vez de improvisar**.

--- a/docs/superpowers/plans/2026-08-19-autenticacao-cognito-otp.md
+++ b/docs/superpowers/plans/2026-08-19-autenticacao-cognito-otp.md
@@ -1497,11 +1497,35 @@ git commit -m "docs: guidelines refletem a autenticacao real"
 
 ---
 
-## Ordem de deploy
+## Deploy
 
-1. `SENSORIANDO_API` fase 1 — rotas de auth no ar (aditivo).
-2. **Este repositório, fase 1** (Tasks 1–7) — `make deploy`.
-3. `SENSORIANDO_API` fases 2 e 3 — o authorizer entra.
-4. **Este repositório, fase 3** (Tasks 8–10).
+**Publicação única, ao fim de tudo.** As fases são marcos de desenvolvimento,
+não publicações separadas.
 
-Publicar o authorizer antes do passo 2 derruba todas as telas privadas.
+A API vai **sempre antes** deste repositório, por uma razão que já existe hoje e
+não tem a ver com autenticação: o `vite.config.ts` chama
+`scripts/resolve_api_url.py` **durante o build**, que lê o output
+`SensoriandoApiUrl` do CloudFormation. Sem a API no ar, o bundle sai com URL
+vazia e o app renderiza "Aplicação sem configuração".
+
+```bash
+cd SENSORIANDO_API        && make deploy
+cd sensoriando_webservice && make deploy
+```
+
+Entre os dois comandos o bundle antigo leva 401 nas rotas privadas — alguns
+minutos, sem usuário real afetado, e o `distribution_paths=["/*"]` do
+`web_stack.py` invalida o CloudFront assim que o bundle novo sobe.
+
+### Antes de escrever a Fase 3
+
+A Fase 1 da API tem uma **verificação obrigatória** contra a AWS de verdade
+(cadastro e login ponta a ponta), descrita no plano dela. Duas das três coisas
+que ela valida decidem o formato de módulos deste repositório:
+
+- se `POST /accounts/confirm` **não** devolver tokens, o `SignUp.tsx` da Task 6
+  precisa mandar o usuário ao login em vez de entrar direto;
+- se o `SECRET_HASH` sobre o e-mail **não** for aceito, `login()` e
+  `verifyOtp()` na Task 3 mudam de assinatura, e a tela da Task 5 junto.
+
+Confirme o resultado dessa verificação antes de começar as Tasks 3, 5 e 6.

--- a/docs/superpowers/plans/2026-08-19-autenticacao-cognito-otp.md
+++ b/docs/superpowers/plans/2026-08-19-autenticacao-cognito-otp.md
@@ -1,0 +1,1507 @@
+# Autenticação via Cognito com OTP — Plano de Implementação (sensoriando_webservice)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Trocar o portão de sessão falso por autenticação real sem senha, e ligar as telas privadas às rotas de conta da API.
+
+**Architecture:** O SPA continua um bundle estático que só consome a API — não fala com o Cognito, não carrega biblioteca de autenticação e não conhece pool id nem client id. O ID token vive apenas em memória; o refresh token fica no `localStorage` e é trocado por um novo ID token pelo próprio `client.ts` quando uma chamada volta 401.
+
+**Tech Stack:** TypeScript 5.9, React 18, react-router-dom 7, Vite 8, vitest 4. **Nenhuma dependência nova.**
+
+**Spec:** `docs/superpowers/specs/2026-08-19-autenticacao-cognito-otp-design.md`
+
+## Global Constraints
+
+- **Idioma:** todo código-fonte, nomes e comentários em **inglês**. Documentação em `docs/` em **português brasileiro**. (`AGENTS.md`)
+- **Não commitar em `main` nem em `develop`.** O trabalho vive em `feat/autenticacao-cognito-otp`. (`AGENTS.md`)
+- **TDD obrigatório:** Red → Green → Refactor.
+- **Nenhuma biblioteca nova.** `docs/guidelines/stacks.md` lista o que é permitido: `react`, `react-dom`, `react-router-dom`, `chart.js`. Nada de gerenciador de estado global, nada de framework de CSS, nada de `eval()`/`new Function()`.
+- **Componentes não fazem rede.** `components/` recebe dados por props; quem busca é `views/`. (`docs/guidelines/architecture.md`)
+- **`api/client.ts` é a única camada que conhece `fetch`.**
+- **Comando de teste:** `cd web && npm test` (ou `make test-web` na raiz).
+- **Estilo:** o `style.css` portado. Nenhuma classe nova sem necessidade; reaproveite `font-17px`, `font-16px`, `signUp`, `home`.
+
+---
+
+# Fase 1 — Autenticação
+
+---
+
+### Task 1: `auth/session.ts` reescrito
+
+**Files:**
+- Modify: `web/src/auth/session.ts`
+- Test: `web/src/auth/session.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `readSession(): Session | null` — `Session` é `{ username: string }`
+  - `writeSession(username: string, refreshToken: string): void`
+  - `clearSession(): void`
+  - `readRefreshToken(): string | null`
+  - `getIdToken(): string | null`
+  - `setIdToken(token: string, expiresIn: number): void`
+  - `clearIdToken(): void`
+
+- [ ] **Step 1: Write the failing tests**
+
+Substitua `web/src/auth/session.test.ts` por (mantendo o helper `memoryStorage` que já está lá):
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearIdToken,
+  clearSession,
+  getIdToken,
+  readRefreshToken,
+  readSession,
+  setIdToken,
+  writeSession,
+} from "./session";
+
+function memoryStorage(): Storage {
+  const entries = new Map<string, string>();
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear: () => entries.clear(),
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => Array.from(entries.keys())[index] ?? null,
+    removeItem: (key: string) => void entries.delete(key),
+    setItem: (key: string, value: string) => void entries.set(key, value),
+  } as Storage;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", memoryStorage());
+  clearIdToken();
+});
+
+describe("session", () => {
+  it("starts with no session", () => {
+    expect(readSession()).toBeNull();
+  });
+
+  it("returns the session that was written", () => {
+    writeSession("fulano", "refresh-token");
+    expect(readSession()).toEqual({ username: "fulano" });
+    expect(readRefreshToken()).toBe("refresh-token");
+  });
+
+  it("clears both the session and the token in memory", () => {
+    writeSession("fulano", "refresh-token");
+    setIdToken("id-token", 3600);
+
+    clearSession();
+
+    expect(readSession()).toBeNull();
+    expect(getIdToken()).toBeNull();
+  });
+
+  it("treats a corrupted entry as no session instead of crashing", () => {
+    localStorage.setItem("sensoriando.session", "{not json");
+    expect(readSession()).toBeNull();
+  });
+
+  it("rejects a session left by the old convenience gate", () => {
+    // It carried a username and no refresh token: it never authenticated
+    // anyone, so it must not be honoured as a session now.
+    localStorage.setItem("sensoriando.session", JSON.stringify({ username: "visitante" }));
+    expect(readSession()).toBeNull();
+  });
+});
+
+describe("the id token", () => {
+  it("never reaches localStorage", () => {
+    writeSession("fulano", "refresh-token");
+    setIdToken("id-token", 3600);
+
+    const stored = localStorage.getItem("sensoriando.session") ?? "";
+    expect(stored).not.toContain("id-token");
+    expect(getIdToken()).toBe("id-token");
+  });
+
+  it("is treated as absent once it is close to expiring", () => {
+    setIdToken("id-token", 30);
+    expect(getIdToken()).toBeNull();
+  });
+
+  it("is dropped by clearIdToken", () => {
+    setIdToken("id-token", 3600);
+    clearIdToken();
+    expect(getIdToken()).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/auth/session.test.ts`
+Expected: FAIL — `setIdToken` não existe.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * The signed-in user, and the two tokens that keep them signed in.
+ *
+ * The ID token -- the one that opens every private route -- lives only in this
+ * module's memory and dies with the tab. Persisting it would leave the
+ * credential that grants immediate access sitting in storage for its whole
+ * hour; keeping it here narrows that window to the page's lifetime.
+ *
+ * The refresh token does persist, because a session that ended on every reload
+ * would be unusable. It buys nothing on its own: it has to be exchanged at
+ * POST /auth/refresh before anything can be read.
+ *
+ * Cognito issues it for 30 days and does not rotate it, so the window does not
+ * slide -- 30 days after signing in, the user does the OTP again.
+ */
+
+const SESSION_KEY = "sensoriando.session";
+
+// A token that expires while the request is still in flight costs a round trip
+// and a retry. Renewing a minute early costs nothing.
+const EXPIRY_SLACK_MS = 60_000;
+
+export interface Session {
+  username: string;
+}
+
+interface StoredSession {
+  username: string;
+  refreshToken: string;
+}
+
+let idToken: string | null = null;
+let idTokenExpiresAt = 0;
+
+function readStored(): StoredSession | null {
+  const stored = localStorage.getItem(SESSION_KEY);
+  if (!stored) return null;
+
+  try {
+    const parsed = JSON.parse(stored) as Partial<StoredSession>;
+    // A session written by the old convenience gate has a username and no
+    // refresh token. It never authenticated anyone, so it is not a session.
+    return typeof parsed.username === "string" && typeof parsed.refreshToken === "string"
+      ? { username: parsed.username, refreshToken: parsed.refreshToken }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readSession(): Session | null {
+  const stored = readStored();
+  return stored ? { username: stored.username } : null;
+}
+
+export function readRefreshToken(): string | null {
+  return readStored()?.refreshToken ?? null;
+}
+
+export function writeSession(username: string, refreshToken: string): void {
+  localStorage.setItem(SESSION_KEY, JSON.stringify({ username, refreshToken }));
+}
+
+export function clearSession(): void {
+  localStorage.removeItem(SESSION_KEY);
+  clearIdToken();
+}
+
+export function getIdToken(): string | null {
+  if (!idToken || Date.now() >= idTokenExpiresAt - EXPIRY_SLACK_MS) return null;
+  return idToken;
+}
+
+export function setIdToken(token: string, expiresIn: number): void {
+  idToken = token;
+  idTokenExpiresAt = Date.now() + expiresIn * 1000;
+}
+
+export function clearIdToken(): void {
+  idToken = null;
+  idTokenExpiresAt = 0;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/auth/session.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/auth/session.ts web/src/auth/session.test.ts
+git commit -m "feat: sessao com refresh token persistido e id token em memoria"
+```
+
+---
+
+### Task 2: `api/client.ts` autentica e renova
+
+**Files:**
+- Modify: `web/src/api/client.ts`
+- Test: `web/src/api/client.test.ts`
+
+**Interfaces:**
+- Consumes: `readSession`, `readRefreshToken`, `getIdToken`, `setIdToken`, `clearIdToken`, `clearSession` (Task 1).
+- Produces: `authGet<T>`, `authPost<T>`, `authPut<T>` com as mesmas assinaturas dos `api*` existentes; `ensureIdToken(baseUrl?): Promise<string>`; `SESSION_EXPIRED` (a mensagem do `ApiError` de sessão perdida). `apiGet`/`apiPost`/`apiPut` ficam inalterados.
+
+- [ ] **Step 1: Write the failing tests**
+
+Acrescente a `web/src/api/client.test.ts`:
+
+```ts
+import { ApiError, SESSION_EXPIRED, apiGet, apiPost, authGet, ensureIdToken } from "./client";
+import { clearIdToken, readSession, setIdToken, writeSession } from "../auth/session";
+
+function memoryStorage(): Storage {
+  const entries = new Map<string, string>();
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear: () => entries.clear(),
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => Array.from(entries.keys())[index] ?? null,
+    removeItem: (key: string) => void entries.delete(key),
+    setItem: (key: string, value: string) => void entries.set(key, value),
+  } as Storage;
+}
+
+describe("authenticated requests", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", memoryStorage());
+    clearIdToken();
+    writeSession("fulano", "refresh-token");
+  });
+
+  it("sends the id token as a bearer credential", async () => {
+    setIdToken("id-token", 3600);
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ username: "fulano" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await authGet("/accounts/private");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer id-token");
+  });
+
+  it("does not send a token on a public request", async () => {
+    setIdToken("id-token", 3600);
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiGet("/sensors");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers?.Authorization).toBeUndefined();
+  });
+
+  it("renews before the first call when only the refresh token survives", async () => {
+    // The state right after a page reload: the id token died with the tab.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ id_token: "novo", expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse({ username: "fulano" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await authGet("/accounts/private");
+
+    expect(fetchMock.mock.calls[0][0]).toBe("/auth/refresh");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      refresh_token: "refresh-token",
+      username: "fulano",
+    });
+    expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe("Bearer novo");
+  });
+
+  it("renews once and retries when a call comes back 401", async () => {
+    setIdToken("velho", 3600);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse({ id_token: "novo", expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse({ username: "fulano" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(authGet("/accounts/private")).resolves.toEqual({ username: "fulano" });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up and clears the session when the refresh itself is rejected", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}, 401));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(authGet("/accounts/private")).rejects.toMatchObject({
+      status: 401,
+      message: SESSION_EXPIRED,
+    });
+    // 30 days elapsed: there is nothing left to renew with.
+    expect(readSession()).toBeNull();
+  });
+
+  it("renews only once for concurrent callers", async () => {
+    // Several views mount at the same time. Without a shared promise this
+    // would fire one refresh per view.
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url === "/auth/refresh") {
+        return Promise.resolve(jsonResponse({ id_token: "novo", expires_in: 3600 }));
+      }
+      return Promise.resolve(jsonResponse([]));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await Promise.all([
+      authGet("/accounts/private"),
+      authPost("/things/private", {}),
+      authGet("/data/stats/private"),
+    ]);
+
+    const refreshes = fetchMock.mock.calls.filter(([url]) => url === "/auth/refresh");
+    expect(refreshes).toHaveLength(1);
+  });
+});
+```
+
+Importe `authPost` junto de `authGet`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/api/client.test.ts`
+Expected: FAIL — `authGet` não é exportado.
+
+- [ ] **Step 3: Implement**
+
+Em `web/src/api/client.ts`, acrescente o import da sessão e reescreva `request` para aceitar um token, mantendo intactos o `ApiError`, o `buildUrl` e os três `api*`:
+
+```ts
+import {
+  clearIdToken,
+  clearSession,
+  getIdToken,
+  readRefreshToken,
+  readSession,
+  setIdToken,
+} from "../auth/session";
+
+/**
+ * The message an ApiError carries when there is no way back to a session:
+ * the refresh token is gone, rejected or 30 days old. The AuthGate matches on
+ * it to send the user to the login screen instead of showing a failure.
+ */
+export const SESSION_EXPIRED = "Sua sessão expirou. Entre novamente.";
+```
+
+`request` ganha um parâmetro:
+
+```ts
+async function request<T>(
+  method: "GET" | "POST" | "PUT",
+  path: string,
+  body: unknown,
+  baseUrl: string,
+  idToken?: string,
+): Promise<T> {
+  const init: RequestInit = { method };
+  const headers: Record<string, string> = {};
+
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    headers["Content-Type"] = "application/json";
+  }
+  if (idToken) {
+    headers.Authorization = `Bearer ${idToken}`;
+  }
+  if (Object.keys(headers).length > 0) {
+    init.headers = headers;
+  }
+
+  // ... o restante do corpo permanece exatamente como está
+}
+```
+
+E ao final do arquivo:
+
+```ts
+// One renewal serves every caller waiting on it. Five views mounting together
+// would otherwise fire five refreshes for the same token.
+let pendingRefresh: Promise<string> | null = null;
+
+async function renew(baseUrl: string): Promise<string> {
+  const session = readSession();
+  const refreshToken = readRefreshToken();
+
+  if (!session || !refreshToken) {
+    throw new ApiError(401, SESSION_EXPIRED);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(buildUrl("/auth/refresh", baseUrl), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: refreshToken, username: session.username }),
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new ApiError(0, `Falha de conexão com a API: ${detail}`);
+  }
+
+  if (!response.ok) {
+    // The refresh token is spent, revoked or past its 30 days. Nothing here
+    // can recover the session, so it is cleared rather than left to fail
+    // again on every screen.
+    clearSession();
+    throw new ApiError(401, SESSION_EXPIRED);
+  }
+
+  const { id_token, expires_in } = (await response.json()) as {
+    id_token: string;
+    expires_in: number;
+  };
+  setIdToken(id_token, expires_in);
+
+  return id_token;
+}
+
+export function ensureIdToken(baseUrl: string = config.apiBaseUrl): Promise<string> {
+  const current = getIdToken();
+  if (current) return Promise.resolve(current);
+
+  pendingRefresh ??= renew(baseUrl).finally(() => {
+    pendingRefresh = null;
+  });
+
+  return pendingRefresh;
+}
+
+async function authenticated<T>(
+  method: "GET" | "POST" | "PUT",
+  path: string,
+  body: unknown,
+  baseUrl: string,
+): Promise<T> {
+  const token = await ensureIdToken(baseUrl);
+
+  try {
+    return await request<T>(method, path, body, baseUrl, token);
+  } catch (error) {
+    if (!(error instanceof ApiError) || error.status !== 401) throw error;
+
+    // The token was refused mid-session. Exactly one retry with a fresh one:
+    // a second 401 means the problem is the session, not the token.
+    clearIdToken();
+    const renewed = await ensureIdToken(baseUrl);
+    return request<T>(method, path, body, baseUrl, renewed);
+  }
+}
+
+export function authGet<T>(path: string, baseUrl: string = config.apiBaseUrl): Promise<T> {
+  return authenticated<T>("GET", path, undefined, baseUrl);
+}
+
+export function authPost<T>(
+  path: string,
+  body?: unknown,
+  baseUrl: string = config.apiBaseUrl,
+): Promise<T> {
+  return authenticated<T>("POST", path, body, baseUrl);
+}
+
+export function authPut<T>(
+  path: string,
+  body?: unknown,
+  baseUrl: string = config.apiBaseUrl,
+): Promise<T> {
+  return authenticated<T>("PUT", path, body, baseUrl);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npm test`
+Expected: PASS, incluindo todos os testes que já existiam de `apiGet`/`apiPost`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/api/client.ts web/src/api/client.test.ts
+git commit -m "feat: header de autenticacao e renovacao compartilhada no client"
+```
+
+---
+
+### Task 3: `api/endpoints.ts`
+
+**Files:**
+- Modify: `web/src/api/endpoints.ts`
+- Test: `web/src/api/endpoints.test.ts`
+
+**Interfaces:**
+- Consumes: `authGet`, `authPost`, `authPut`, `apiPost` (Task 2).
+- Produces:
+  - `AuthTokens` = `{ username: string; id_token: string; refresh_token: string; expires_in: number }`
+  - `signUp(input: AccountInput): Promise<{ destination: string }>`
+  - `confirmSignUp(input: { username: string; code: string }): Promise<AuthTokens>`
+  - `resendCode(input: { username: string }): Promise<{ destination: string }>`
+  - `login(input: { email: string }): Promise<{ session: string; destination: string }>`
+  - `verifyOtp(input: { email: string; code: string; session: string }): Promise<AuthTokens>`
+  - `AccountInput` = `{ username, name, email, phone?, city, state, country }`
+  - `ProfileInput` = `{ name, phone?, city, state, country }`
+  - `PrivateAccount` = `ProfileInput & { username, email }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Acrescente a `web/src/api/endpoints.test.ts`, seguindo o padrão de stub de `fetch` já usado ali:
+
+```ts
+it("posts the registration without a password", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ destination: "f***@e***.com" }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await signUp({
+    username: "fulano",
+    name: "Fulano de Tal",
+    email: "fulano@example.com",
+    city: "Ribeirão Preto",
+    state: "SP",
+    country: "BR",
+  });
+
+  const [url, init] = fetchMock.mock.calls[0];
+  expect(url).toBe("/accounts");
+  expect(init.method).toBe("POST");
+  expect(JSON.parse(init.body)).not.toHaveProperty("password");
+});
+
+it("confirms the registration by username and code", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(
+    jsonResponse({ username: "fulano", id_token: "id", refresh_token: "r", expires_in: 3600 }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(confirmSignUp({ username: "fulano", code: "123456" })).resolves.toMatchObject({
+    id_token: "id",
+  });
+  expect(fetchMock.mock.calls[0][0]).toBe("/accounts/confirm");
+});
+
+it("starts a sign-in with the e-mail alone", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ session: "s", destination: "d" }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await login({ email: "fulano@example.com" });
+
+  expect(fetchMock.mock.calls[0][0]).toBe("/auth/login");
+  expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+    email: "fulano@example.com",
+  });
+});
+
+it("answers the challenge with the code and the session", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(
+    jsonResponse({ username: "fulano", id_token: "id", refresh_token: "r", expires_in: 3600 }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+
+  await verifyOtp({ email: "fulano@example.com", code: "123456", session: "s" });
+
+  expect(fetchMock.mock.calls[0][0]).toBe("/auth/verify");
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/api/endpoints.test.ts`
+Expected: FAIL — `signUp` não é exportado.
+
+- [ ] **Step 3: Implement**
+
+Em `web/src/api/endpoints.ts`:
+
+1. Importe `authGet, authPost, authPut` além dos `api*`.
+2. Troque os tipos:
+
+```ts
+export interface AccountInput {
+  username: string;
+  name: string;
+  email: string;
+  phone?: string;
+  city: string;
+  state: string;
+  country: string;
+}
+
+export interface ProfileInput {
+  name: string;
+  phone?: string;
+  city: string;
+  state: string;
+  country: string;
+}
+
+export interface PrivateAccount extends ProfileInput {
+  username: string;
+  email: string;
+}
+
+export interface AuthTokens {
+  username: string;
+  id_token: string;
+  refresh_token: string;
+  expires_in: number;
+}
+```
+
+3. **Remova** `PreferredUnitInput` e `savePreferredUnit`. A preferência de unidade não tem tabela no schema e passa a viver em `lib/prefs.ts` (Task 8).
+
+4. Acrescente a seção de identidade:
+
+```ts
+// --- Identity ---------------------------------------------------------------
+//
+// The browser never talks to Cognito: every one of these is an endpoint of the
+// API, which brokers the conversation. That is why this app carries no
+// authentication library and the build injects no pool or client id.
+
+export function signUp(input: AccountInput): Promise<{ destination: string }> {
+  return apiPost<{ destination: string }>("/accounts", input);
+}
+
+// Takes the username, not the e-mail: the user has just chosen it in the form,
+// and the API does not have to resolve an alias to confirm the account.
+export function confirmSignUp(input: {
+  username: string;
+  code: string;
+}): Promise<AuthTokens> {
+  return apiPost<AuthTokens>("/accounts/confirm", input);
+}
+
+export function resendCode(input: { username: string }): Promise<{ destination: string }> {
+  return apiPost<{ destination: string }>("/accounts/code", input);
+}
+
+// The answer looks the same whether or not the address is registered: the pool
+// runs with PreventUserExistenceErrors so this cannot be used to find out who
+// has an account. An unknown address only fails at verifyOtp.
+export function login(input: {
+  email: string;
+}): Promise<{ session: string; destination: string }> {
+  return apiPost<{ session: string; destination: string }>("/auth/login", input);
+}
+
+export function verifyOtp(input: {
+  email: string;
+  code: string;
+  session: string;
+}): Promise<AuthTokens> {
+  return apiPost<AuthTokens>("/auth/verify", input);
+}
+```
+
+5. Mova as rotas privadas para fora de `pending()` e para os verbos autenticados:
+
+```ts
+export function listPrivateThings(filters: ThingFilters = {}): Promise<Thing[]> {
+  return authPost<Thing[]>("/things/private", filters);
+}
+
+export function readPrivateDetail(query: DetailQuery): Promise<Reading[]> {
+  return authPost<Reading[]>("/data/detail/private", query);
+}
+
+export function readPrivateStats(): Promise<Stats> {
+  return authGet<Stats>("/data/stats/private");
+}
+
+export function listSensorUnits(): Promise<SensorUnit[]> {
+  return apiGet<SensorUnit[]>("/sensors/units");
+}
+
+export function readPrivateAccount(): Promise<PrivateAccount> {
+  return authGet<PrivateAccount>("/accounts/private");
+}
+
+export function savePrivateAccount(input: ProfileInput): Promise<void> {
+  return authPut<void>("/accounts/private", input);
+}
+
+export function linkThing(input: { uuid: string }): Promise<void> {
+  return authPost<void>("/accounts/private/things", input);
+}
+```
+
+6. Remova `createAccount`. **Mantenha** `PENDING_MESSAGE`, `PENDING_STATUSES` e `pending()` com seus comentários: continuam úteis para a próxima rota que a API ainda não expuser.
+
+Se `pending()` ficar sem chamador e o lint reclamar, mantenha-a exportada — está documentada como parte do contrato do módulo.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npm test`
+Expected: FAIL de compilação em `SignUp.tsx` e `Account.tsx`, que ainda usam os tipos antigos. Isso é esperado e será resolvido nas Tasks 5, 6 e 9. Os testes de `endpoints.test.ts` devem passar.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/api/endpoints.ts web/src/api/endpoints.test.ts
+git commit -m "feat: endpoints de identidade e rotas privadas autenticadas"
+```
+
+---
+
+### Task 4: `auth/AuthGate.tsx` com estado de carregamento
+
+**Files:**
+- Modify: `web/src/auth/AuthGate.tsx`
+- Create: `web/src/auth/AuthGate.test.tsx`
+
+**Interfaces:**
+- Consumes: `readSession` (Task 1), `ensureIdToken`, `SESSION_EXPIRED` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AuthGate from "./AuthGate";
+
+vi.mock("./session", () => ({ readSession: vi.fn() }));
+vi.mock("../api/client", () => ({
+  ensureIdToken: vi.fn(),
+  SESSION_EXPIRED: "Sua sessão expirou. Entre novamente.",
+}));
+
+import { ensureIdToken } from "../api/client";
+import { readSession } from "./session";
+
+function renderGate() {
+  return render(
+    <MemoryRouter initialEntries={["/home/private"]}>
+      <Routes>
+        <Route
+          path="/home/private"
+          element={
+            <AuthGate>
+              <p>conteúdo privado</p>
+            </AuthGate>
+          }
+        />
+        <Route path="/users/login" element={<p>tela de login</p>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(readSession).mockReset();
+  vi.mocked(ensureIdToken).mockReset();
+});
+
+describe("AuthGate", () => {
+  it("sends an anonymous visitor to the login screen", () => {
+    vi.mocked(readSession).mockReturnValue(null);
+
+    renderGate();
+
+    expect(screen.getByText("tela de login")).toBeTruthy();
+  });
+
+  it("renews before rendering, because the id token died with the tab", async () => {
+    // Without this the first request of every private screen would be a 401.
+    vi.mocked(readSession).mockReturnValue({ username: "fulano" });
+    vi.mocked(ensureIdToken).mockResolvedValue("id-token");
+
+    renderGate();
+
+    await waitFor(() => expect(screen.getByText("conteúdo privado")).toBeTruthy());
+    expect(ensureIdToken).toHaveBeenCalled();
+  });
+
+  it("sends the user to the login screen when the renewal fails", async () => {
+    vi.mocked(readSession).mockReturnValue({ username: "fulano" });
+    vi.mocked(ensureIdToken).mockRejectedValue(new Error("expired"));
+
+    renderGate();
+
+    await waitFor(() => expect(screen.getByText("tela de login")).toBeTruthy());
+  });
+});
+```
+
+Este é o primeiro teste de componente do repositório. Ele precisa de `@testing-library/react`, `@testing-library/jest-dom` e `jsdom` como **devDependencies**, e de `test: { environment: "jsdom" }` em `vite.config.ts`. Instale com versão fixada e **registre em `docs/guidelines/stacks.md` na seção de Desenvolvimento** — a restrição do projeto é sobre bibliotecas de runtime, e o `stacks.md` já lista `vitest` e `@types/*` ali:
+
+```bash
+cd web && npm install --save-exact --save-dev @testing-library/react @testing-library/dom jsdom
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && npx vitest run src/auth/AuthGate.test.tsx`
+Expected: FAIL — o gate ainda é síncrono e nunca chama `ensureIdToken`.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+import { type ReactNode, useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+
+import Loading from "../components/Loading";
+import { ensureIdToken } from "../api/client";
+import { readSession } from "./session";
+
+interface Props {
+  children: ReactNode;
+}
+
+type Status = "checking" | "allowed" | "denied";
+
+/**
+ * The gate in front of every private screen.
+ *
+ * It cannot decide synchronously any more. The id token lives in memory, so a
+ * reload leaves a valid session with no token at all -- and rendering the
+ * children in that state would make the first request of every screen a 401.
+ * The gate renews first and only then lets them through.
+ */
+export default function AuthGate({ children }: Props) {
+  const [status, setStatus] = useState<Status>(() =>
+    readSession() ? "checking" : "denied",
+  );
+
+  useEffect(() => {
+    if (status !== "checking") return;
+
+    let active = true;
+    ensureIdToken()
+      .then(() => {
+        if (active) setStatus("allowed");
+      })
+      .catch(() => {
+        // The refresh token is gone or past its 30 days. clearSession has
+        // already run inside the client; there is nothing to do but ask for
+        // the OTP again.
+        if (active) setStatus("denied");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [status]);
+
+  if (status === "checking") return <Loading />;
+  if (status === "denied") return <Navigate to="/users/login" replace />;
+
+  return <>{children}</>;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/auth/AuthGate.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/auth/AuthGate.tsx web/src/auth/AuthGate.test.tsx web/package.json web/package-lock.json web/vite.config.ts docs/guidelines/stacks.md
+git commit -m "feat: portao privado renova a sessao antes de renderizar"
+```
+
+---
+
+### Task 5: `views/LoginPage.tsx` em duas etapas
+
+**Files:**
+- Modify: `web/src/views/LoginPage.tsx`
+- Create: `web/src/views/LoginPage.test.tsx`
+
+**Interfaces:**
+- Consumes: `login`, `verifyOtp` (Task 3); `writeSession`, `setIdToken` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/endpoints", () => ({ login: vi.fn(), verifyOtp: vi.fn() }));
+vi.mock("../auth/session", () => ({ writeSession: vi.fn(), setIdToken: vi.fn() }));
+
+import LoginPage from "./LoginPage";
+import { login, verifyOtp } from "../api/endpoints";
+import { setIdToken, writeSession } from "../auth/session";
+
+beforeEach(() => {
+  vi.mocked(login).mockReset();
+  vi.mocked(verifyOtp).mockReset();
+  vi.mocked(writeSession).mockReset();
+});
+
+describe("LoginPage", () => {
+  it("asks for the code only after the e-mail was submitted", async () => {
+    vi.mocked(login).mockResolvedValue({ session: "s", destination: "f***@e***.com" });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByLabelText(/código/i)).toBeNull();
+
+    await userEvent.type(screen.getByLabelText(/e-mail/i), "fulano@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /receber código/i }));
+
+    await waitFor(() => expect(screen.getByLabelText(/código/i)).toBeTruthy());
+    // The masked address tells the user which inbox to open.
+    expect(screen.getByText(/f\*\*\*@e\*\*\*\.com/)).toBeTruthy();
+  });
+
+  it("stores the session that verifying the code returns", async () => {
+    vi.mocked(login).mockResolvedValue({ session: "s", destination: "d" });
+    vi.mocked(verifyOtp).mockResolvedValue({
+      username: "fulano",
+      id_token: "id",
+      refresh_token: "refresh",
+      expires_in: 3600,
+    });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    await userEvent.type(screen.getByLabelText(/e-mail/i), "fulano@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /receber código/i }));
+    await waitFor(() => screen.getByLabelText(/código/i));
+
+    await userEvent.type(screen.getByLabelText(/código/i), "123456");
+    await userEvent.click(screen.getByRole("button", { name: /entrar/i }));
+
+    await waitFor(() =>
+      expect(writeSession).toHaveBeenCalledWith("fulano", "refresh"),
+    );
+    expect(setIdToken).toHaveBeenCalledWith("id", 3600);
+  });
+
+  it("shows the message when the code is refused", async () => {
+    vi.mocked(login).mockResolvedValue({ session: "s", destination: "d" });
+    vi.mocked(verifyOtp).mockRejectedValue(
+      Object.assign(new Error("código inválido"), { name: "ApiError", status: 400 }),
+    );
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    await userEvent.type(screen.getByLabelText(/e-mail/i), "fulano@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /receber código/i }));
+    await waitFor(() => screen.getByLabelText(/código/i));
+
+    await userEvent.type(screen.getByLabelText(/código/i), "000000");
+    await userEvent.click(screen.getByRole("button", { name: /entrar/i }));
+
+    await waitFor(() => expect(screen.getByText(/código inválido/i)).toBeTruthy());
+  });
+});
+```
+
+Instale `@testing-library/user-event` com `--save-exact --save-dev` e registre no `stacks.md`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && npx vitest run src/views/LoginPage.test.tsx`
+Expected: FAIL — a tela ainda tem só o botão "Entrar" do portão falso.
+
+- [ ] **Step 3: Implement**
+
+Reescreva `web/src/views/LoginPage.tsx` com estado `"email" | "code"`, usando `ErrorBanner` para o erro e o mesmo markup (`section.home`, `section.signUp`, `font-36px`, `font-17px`, `font-16px`) que a tela já usa. Requisitos que os testes fixam:
+
+- etapa 1: `<label htmlFor="email">E-mail</label>` e botão "Receber código";
+- etapa 2: `<label htmlFor="code">Código</label>`, o `destination` visível no texto, botão "Entrar" e um botão "Reenviar código" que volta à etapa 1;
+- sucesso: `writeSession(username, refresh_token)`, `setIdToken(id_token, expires_in)`, `navigate("/home/private")`;
+- erro: mensagem do `ApiError`, ou `"Falha inesperada ao entrar"`.
+
+Inclua na etapa 1 o aviso, em `font-17px`:
+
+> Enviaremos um código de acesso para o seu e-mail. Não há senha. A sessão dura 30 dias.
+
+E o comentário de módulo:
+
+```tsx
+/**
+ * Sign-in in two steps: an address, then the code that arrives in it.
+ *
+ * The first step always advances, even for an address with no account: the API
+ * answers the same either way, on purpose, so that this screen cannot be used
+ * to find out who is registered. An unknown address only fails at the code.
+ */
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/views/LoginPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/views/LoginPage.tsx web/src/views/LoginPage.test.tsx web/package.json web/package-lock.json docs/guidelines/stacks.md
+git commit -m "feat: login em duas etapas com codigo por e-mail"
+```
+
+---
+
+### Task 6: `views/SignUp.tsx` em duas etapas
+
+**Files:**
+- Modify: `web/src/views/SignUp.tsx`
+- Create: `web/src/views/SignUp.test.tsx`
+
+**Interfaces:**
+- Consumes: `signUp`, `confirmSignUp`, `resendCode` (Task 3); `writeSession`, `setIdToken` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+vi.mock("../api/endpoints", () => ({
+  signUp: vi.fn(),
+  confirmSignUp: vi.fn(),
+  resendCode: vi.fn(),
+}));
+vi.mock("../auth/session", () => ({ writeSession: vi.fn(), setIdToken: vi.fn() }));
+
+// ... imports as in LoginPage.test.tsx
+
+const FORM = {
+  username: "fulano",
+  name: "Fulano de Tal",
+  email: "fulano@example.com",
+  city: "Ribeirão Preto",
+};
+
+async function fillTheForm() {
+  await userEvent.type(screen.getByLabelText(/^usuário/i), FORM.username);
+  await userEvent.type(screen.getByLabelText(/^nome/i), FORM.name);
+  await userEvent.type(screen.getByLabelText(/e-mail/i), FORM.email);
+  await userEvent.type(screen.getByLabelText(/cidade/i), FORM.city);
+}
+
+describe("SignUp", () => {
+  it("has no password field, because the platform has no passwords", () => {
+    render(<MemoryRouter><SignUp /></MemoryRouter>);
+
+    expect(screen.queryByLabelText(/senha/i)).toBeNull();
+  });
+
+  it("limits the username to what the column holds", () => {
+    render(<MemoryRouter><SignUp /></MemoryRouter>);
+
+    // accounts.username is VARCHAR(20).
+    expect(screen.getByLabelText(/^usuário/i).getAttribute("maxLength")).toBe("20");
+  });
+
+  it("signs the user in as soon as the code is confirmed", async () => {
+    vi.mocked(signUp).mockResolvedValue({ destination: "f***@e***.com" });
+    vi.mocked(confirmSignUp).mockResolvedValue({
+      username: "fulano",
+      id_token: "id",
+      refresh_token: "refresh",
+      expires_in: 3600,
+    });
+
+    render(<MemoryRouter><SignUp /></MemoryRouter>);
+
+    await fillTheForm();
+    await userEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
+    await waitFor(() => screen.getByLabelText(/código/i));
+
+    await userEvent.type(screen.getByLabelText(/código/i), "123456");
+    await userEvent.click(screen.getByRole("button", { name: /confirmar/i }));
+
+    // Confirming with the OTP already proves the e-mail, so Cognito hands back
+    // a session: the user never types a second code.
+    await waitFor(() => expect(writeSession).toHaveBeenCalledWith("fulano", "refresh"));
+  });
+
+  it("reports a duplicated e-mail without losing what was typed", async () => {
+    vi.mocked(signUp).mockRejectedValue(
+      Object.assign(new Error("este e-mail já tem conta"), { name: "ApiError", status: 409 }),
+    );
+
+    render(<MemoryRouter><SignUp /></MemoryRouter>);
+
+    await fillTheForm();
+    await userEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
+
+    await waitFor(() => expect(screen.getByText(/já tem conta/i)).toBeTruthy());
+    expect((screen.getByLabelText(/^nome/i) as HTMLInputElement).value).toBe(FORM.name);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && npx vitest run src/views/SignUp.test.tsx`
+Expected: FAIL — o campo de senha ainda existe.
+
+- [ ] **Step 3: Implement**
+
+Reescreva `web/src/views/SignUp.tsx`:
+
+- `EMPTY` vira `{ username: "", name: "", email: "", phone: "", city: "", state: BRAZIL_STATES[0].value, country: COUNTRIES[0].value }`. **Sem `password`, sem `first_name`, sem `last_name`.**
+- Campos: Usuário (`maxLength={20}`, `required`), Nome (`required`), E-mail (`type="email"`, `required`), Telefone (**sem** `required`), Cidade (`required`), Estado (`select`), País (`select`).
+- Estado `"form" | "code"`; `submit` chama `signUp(form)` e guarda `destination`.
+- Etapa do código: `<label htmlFor="code">Código</label>`, botão "Confirmar", botão "Reenviar código" chamando `resendCode({ username: form.username })`.
+- Sucesso: `writeSession(...)`, `setIdToken(...)`, `navigate("/home/private")`.
+- Um `502` (`caught.status === 502`) mostra a mensagem da API e um link para `/users/login` — a conta existe, e o primeiro login refaz o provisionamento.
+- O estado do formulário **não é limpo** em caso de erro.
+
+Comentário de módulo:
+
+```tsx
+/**
+ * Registration in two steps, with no password anywhere.
+ *
+ * The first step only creates the Cognito user: name, phone and address wait
+ * as attributes on it, and nothing reaches the ERP until the address is
+ * proven. The second step confirms the code -- which both verifies the e-mail
+ * and signs the user in, so they land logged in rather than at the login
+ * screen.
+ */
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npm test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/views/SignUp.tsx web/src/views/SignUp.test.tsx
+git commit -m "feat: cadastro sem senha com confirmacao por codigo"
+```
+
+---
+
+### Task 7: `components/Header.tsx`
+
+**Files:**
+- Modify: `web/src/components/Header.tsx`
+
+`clearSession()` já limpa o ID token desde a Task 1, então o "Sair" está correto por construção. Esta task só confirma isso e ajusta o comentário.
+
+- [ ] **Step 1: Read and verify**
+
+Run: `cd web && cat src/components/Header.tsx`
+
+Confirme que o `onClick` de "Sair" chama `clearSession()` e depois navega/recarrega, e que nada mais lê o token diretamente:
+
+Run: `grep -rn "getIdToken\|setIdToken" web/src --include=*.tsx`
+Expected: nenhum resultado fora de `auth/` e `api/`.
+
+- [ ] **Step 2: Update the comment**
+
+O comentário atual explica que `clearSession` só mexe no `localStorage`, que React não observa. Ele agora está incompleto: acrescente que a limpeza também descarta o token em memória.
+
+```tsx
+  // clearSession only touches localStorage and a module-level variable, and
+  // React observes neither. The reload is what makes every screen see that the
+  // session is gone.
+```
+
+- [ ] **Step 3: Run the suite**
+
+Run: `cd web && npm test`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Header.tsx
+git commit -m "docs: comentario do logout cobre o token em memoria"
+```
+
+---
+
+# Fase 3 — Conta
+
+A fase 2 não tem trabalho neste repositório: é o deploy do authorizer no lado da API. **Publique esta fase somente depois disso.**
+
+---
+
+### Task 8: unidade preferida em `lib/prefs.ts`
+
+**Files:**
+- Modify: `web/src/lib/prefs.ts`
+- Test: `web/src/lib/prefs.test.ts`
+
+**Interfaces:**
+- Produces: `readPreferredUnit(sensorId: number): number | null`, `writePreferredUnit(sensorId: number, unitId: number): void`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("preferred unit", () => {
+  it("has none until one is chosen", () => {
+    expect(readPreferredUnit(3)).toBeNull();
+  });
+
+  it("returns the unit that was chosen for that sensor", () => {
+    writePreferredUnit(3, 7);
+    writePreferredUnit(4, 9);
+
+    expect(readPreferredUnit(3)).toBe(7);
+    expect(readPreferredUnit(4)).toBe(9);
+  });
+
+  it("treats a corrupted entry as no preference", () => {
+    localStorage.setItem("unit3", "nem numero");
+    expect(readPreferredUnit(3)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/lib/prefs.test.ts`
+Expected: FAIL — `readPreferredUnit` não existe.
+
+- [ ] **Step 3: Implement**
+
+```ts
+const preferredUnitKey = (sensorId: number) => `unit${sensorId}`;
+
+/**
+ * Which unit this browser shows for a sensor.
+ *
+ * It is a browser preference, not an account setting: the schema has no table
+ * linking an account to a unit -- `sensorsunits` is a catalogue with a global
+ * `isdefault` -- and adding one would mean changing the Core's database. So it
+ * sits beside the period and the chart type, which are stored the same way.
+ */
+export function readPreferredUnit(sensorId: number): number | null {
+  const stored = localStorage.getItem(preferredUnitKey(sensorId));
+  if (stored === null) return null;
+
+  const parsed = Number(stored);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+export function writePreferredUnit(sensorId: number, unitId: number): void {
+  localStorage.setItem(preferredUnitKey(sensorId), String(unitId));
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/lib/prefs.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/prefs.ts web/src/lib/prefs.test.ts
+git commit -m "feat: unidade preferida por sensor no armazenamento local"
+```
+
+---
+
+### Task 9: `views/Account.tsx` nas três abas
+
+**Files:**
+- Modify: `web/src/views/Account.tsx`
+- Create: `web/src/views/Account.test.tsx`
+
+**Interfaces:**
+- Consumes: `readPrivateAccount`, `savePrivateAccount`, `linkThing`, `listSensorUnits` (Task 3); `readPreferredUnit`, `writePreferredUnit` (Task 8).
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+vi.mock("../api/endpoints", () => ({
+  readPrivateAccount: vi.fn(),
+  savePrivateAccount: vi.fn(),
+  linkThing: vi.fn(),
+  listSensorUnits: vi.fn(),
+  listPrivateThings: vi.fn(),
+}));
+
+const ACCOUNT = {
+  username: "fulano",
+  name: "Fulano de Tal",
+  email: "fulano@example.com",
+  phone: "16999991234",
+  city: "Ribeirão Preto",
+  state: "SP",
+  country: "BR",
+};
+
+function renderProfile() {
+  return render(
+    <MemoryRouter initialEntries={["/users/account/fulano/profile"]}>
+      <Routes>
+        <Route path="/users/account/:username/:tab" element={<Account />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("the profile tab", () => {
+  it("shows one name field, because the ERP stores one name", async () => {
+    vi.mocked(readPrivateAccount).mockResolvedValue(ACCOUNT);
+
+    renderProfile();
+
+    await waitFor(() =>
+      expect((screen.getByLabelText(/^nome/i) as HTMLInputElement).value).toBe(
+        "Fulano de Tal",
+      ),
+    );
+    expect(screen.queryByLabelText(/sobrenome/i)).toBeNull();
+  });
+
+  it("does not let the e-mail be edited", async () => {
+    vi.mocked(readPrivateAccount).mockResolvedValue(ACCOUNT);
+
+    renderProfile();
+
+    // It is what authenticates: changing it here would not change the login.
+    await waitFor(() =>
+      expect((screen.getByLabelText(/e-mail/i) as HTMLInputElement).readOnly).toBe(true),
+    );
+  });
+
+  it("saves without the fields it does not own", async () => {
+    vi.mocked(readPrivateAccount).mockResolvedValue(ACCOUNT);
+    vi.mocked(savePrivateAccount).mockResolvedValue(undefined);
+
+    renderProfile();
+    await waitFor(() => screen.getByLabelText(/^nome/i));
+    await userEvent.click(screen.getByRole("button", { name: /salvar/i }));
+
+    const sent = vi.mocked(savePrivateAccount).mock.calls[0][0];
+    expect(sent).not.toHaveProperty("username");
+    expect(sent).not.toHaveProperty("email");
+  });
+});
+```
+
+Acrescente um teste da aba de centrais verificando que um `409` de `linkThing` vira a mensagem "esta central já pertence a uma conta".
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/views/Account.test.tsx`
+Expected: FAIL — a aba ainda usa `first_name`/`last_name`.
+
+- [ ] **Step 3: Implement**
+
+Em `web/src/views/Account.tsx`:
+
+- **`ProfileTab`**: o `useEffect` passa a montar `{ name, phone, city, state, country }` a partir de `account.data`. O campo E-mail vira `readOnly` e não entra no `ProfileInput` enviado. Trate `409` (conta não provisionada) com uma mensagem própria: "Conta ainda não registrada. Entre novamente para concluir o cadastro."
+- **`ThingsTab`**: `linkThing` sai de `pending()`. Mapeie `404` → "Central não encontrada." e `409` → "Esta central já pertence a uma conta."
+- **`SensorsTab`**: remova o import e o uso de `savePreferredUnit`; a escolha de unidade passa a chamar `writePreferredUnit(sensorId, unitId)` e o valor inicial vem de `readPreferredUnit(sensorId)`, exatamente como `readChartType`/`writeChartType` já fazem ao lado. Remova o array `PRECISIONS` e o comentário sobre `MAX_PRECISION` se a precisão deixar de ser editável — ela vem do catálogo em `listSensorUnits()`.
+
+Acrescente ao topo da aba de sensores:
+
+```tsx
+// The unit is a browser preference, not an account setting: there is no table
+// in the schema linking an account to a unit. See lib/prefs.ts.
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npm test && npm run build`
+Expected: PASS, e o `tsc -b` do build sem erro — é aqui que os tipos trocados na Task 3 terminam de fechar.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/views/Account.tsx web/src/views/Account.test.tsx
+git commit -m "feat: telas de perfil, centrais e sensores contra a API real"
+```
+
+---
+
+### Task 10: Guidelines atualizadas
+
+**Files:**
+- Modify: `docs/guidelines/architecture.md`
+- Modify: `docs/guidelines/stacks.md`
+
+- [ ] **Step 1: Update `architecture.md`**
+
+- No diagrama, acrescente o Cognito **atrás da API**, não ao lado do navegador:
+
+```
+Navegador → CloudFront → S3 (bundle estático)
+    │
+    └── HTTPS → API Gateway → Lambdas → PostgreSQL (Neon)
+                     │            └────→ Cognito (identidade)
+                     └── authorizer valida o ID token
+```
+
+- Em "Módulos Principais", reescreva a linha de `auth/`:
+
+```
+  auth/         session.ts    → refresh token no localStorage, ID token em memória
+                AuthGate.tsx  → renova antes de renderizar; redireciona quem não tem sessão
+```
+
+- Em "Fluxo de Dados", acrescente um item explicando que `client.ts` injeta o ID token nas rotas privadas e renova uma vez no 401, com renovação compartilhada entre chamadas concorrentes.
+
+- [ ] **Step 2: Update `stacks.md`**
+
+- Em "Serviços de Nuvem Utilizados", acrescente:
+
+```
+- **Cognito** — identidade dos usuários. Alcançado **pela API**, nunca pelo
+  navegador: o SPA não conhece pool id nem client id.
+```
+
+- Em "Bibliotecas Permitidas → Desenvolvimento", acrescente as instaladas nas Tasks 4 e 5 (`@testing-library/react`, `@testing-library/dom`, `@testing-library/user-event`, `jsdom`) com as versões fixadas.
+
+- Na seção do SPA, acrescente:
+
+```
+Nenhuma biblioteca de autenticação. Como a API intermedia o Cognito, o SPA não
+precisa de `oidc-client-ts` nem `amazon-cognito-identity-js`.
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -rn "portão de conveniência\|convenience gate" docs/ web/src`
+Expected: nenhum resultado — a expressão descrevia o que foi removido.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guidelines
+git commit -m "docs: guidelines refletem a autenticacao real"
+```
+
+---
+
+## Ordem de deploy
+
+1. `SENSORIANDO_API` fase 1 — rotas de auth no ar (aditivo).
+2. **Este repositório, fase 1** (Tasks 1–7) — `make deploy`.
+3. `SENSORIANDO_API` fases 2 e 3 — o authorizer entra.
+4. **Este repositório, fase 3** (Tasks 8–10).
+
+Publicar o authorizer antes do passo 2 derruba todas as telas privadas.

--- a/docs/superpowers/specs/2026-08-19-autenticacao-cognito-otp-design.md
+++ b/docs/superpowers/specs/2026-08-19-autenticacao-cognito-otp-design.md
@@ -1,0 +1,284 @@
+# Autenticação via Cognito com OTP por e-mail — sensoriando_webservice
+
+Data: 2026-08-19
+Repositórios envolvidos: `sensoriando_webservice` (este) e `SENSORIANDO_API`
+Spec par: `SENSORIANDO_API/docs/superpowers/specs/2026-08-19-autenticacao-cognito-otp-design.md`
+
+---
+
+## 1. Objetivo
+
+Trocar o portão de sessão falso por autenticação real, sem senha: o usuário
+informa o e-mail, recebe um código de uso único e o digita.
+
+O SPA continua sendo um bundle estático que **só consome a API**. Ele não fala
+com o Cognito, não carrega biblioteca de autenticação e não conhece pool id nem
+client id. Toda a conversa com o Cognito acontece do lado servidor, nos
+endpoints descritos no spec par.
+
+Este spec cobre o lado navegador.
+
+---
+
+## 2. Estado de partida
+
+`web/src/auth/session.ts` declara o que ele é hoje, no próprio docstring:
+
+> A convenience gate, not a security boundary. […] the gate only keeps the
+> private screens out of the way until real authentication (Cognito) lands.
+
+Não há senha, e as rotas `/private` da API servem a conta fixa de
+`PRIVATE_ACCOUNT_USERNAME` independentemente de quem entrou. Este spec é o
+"until Cognito lands".
+
+Seis rotas estão marcadas como pendentes em `api/endpoints.ts` pela função
+`pending()`. Cinco passam a existir; uma sai (seção 7).
+
+---
+
+## 3. Decisões
+
+| # | Decisão | Razão |
+|---|---------|-------|
+| D1 | Nenhuma biblioteca nova | Como a API intermedia o Cognito, `oidc-client-ts` e `amazon-cognito-identity-js` são desnecessários. `stacks.md` fica intacto na lista de bibliotecas permitidas. |
+| D2 | Nada de novo no build | A URL da API já vem do CloudFormation via `scripts/resolve_api_url.py`. Pool id e client id não são injetados porque o navegador nunca os usa. |
+| D3 | ID token **só em memória**; refresh token em `localStorage` | Reduz a janela em que um XSS captura o token que dá acesso imediato. O refresh token persiste para o usuário continuar logado entre visitas. |
+| D4 | Sessão de 30 dias, sem deslizar | Prazo do refresh token no Cognito, contado da emissão. Passados 30 dias o usuário refaz o OTP mesmo tendo usado todo dia. |
+| D5 | Renovação com promessa compartilhada | Várias views carregam em paralelo; sem isso, cinco 401 simultâneos disparariam cinco renovações. |
+| D6 | `name` único, sem `first_name`/`last_name` | `res.partner.name` no Odoo é um campo só. Quebrar por espaço seria adivinhação. |
+| D7 | Unidade preferida vai para `localStorage` | Não existe tabela no schema que ligue conta a unidade. `lib/prefs.ts` já guarda período e tipo de gráfico exatamente assim. |
+
+---
+
+## 4. Sessão
+
+### 4.1 `web/src/auth/session.ts` — reescrito
+
+Deixa de ser portão de conveniência. Passa a guardar:
+
+- em `localStorage`: `{ username, refreshToken }`
+- em variável de módulo, **fora do `localStorage`**: o ID token e o instante em
+  que expira
+
+```ts
+export interface Session { username: string; }
+
+export function readSession(): Session | null;
+export function writeSession(username: string, refreshToken: string): void;
+export function clearSession(): void;
+
+export function readRefreshToken(): string | null;
+export function getIdToken(): string | null;      // memória
+export function setIdToken(token: string, expiresIn: number): void;
+export function clearIdToken(): void;
+```
+
+A chave `sensoriando.session` do `localStorage` é reaproveitada. Uma sessão
+antiga, gravada pelo portão falso, tem `username` mas não tem `refreshToken`:
+`readSession()` devolve `null` nesse caso, e o usuário cai no login. É a
+migração — não há usuário real para preservar, já que o portão nunca autenticou
+ninguém.
+
+O docstring do módulo é reescrito: deixa de dizer que não é fronteira de
+segurança, e passa a explicar por que o ID token não é persistido.
+
+### 4.2 `web/src/api/client.ts` — alterado
+
+- `request()` recebe se a chamada é autenticada. Sendo, injeta
+  `Authorization: Bearer <idToken>`.
+- Sem ID token em memória mas com refresh token guardado (caso do boot), renova
+  antes de enviar.
+- Resposta `401` numa chamada autenticada: renova **uma vez** e repete a
+  requisição. Segundo `401` → limpa a sessão e propaga um `ApiError` que o
+  `AuthGate` reconhece como "precisa entrar de novo".
+- A renovação é uma **promessa compartilhada** em variável de módulo: chamadas
+  concorrentes aguardam a mesma, e ela é limpa ao resolver ou rejeitar.
+
+`ApiError` continua com a mesma forma. A distinção entre "servidor disse não" e
+"não houve servidor" pelo `status === 0` permanece.
+
+### 4.3 `web/src/auth/AuthGate.tsx` — alterado
+
+Hoje é síncrono: lê o `localStorage` e decide. Passa a ter três estados, porque
+no boot existe refresh token mas ainda não existe ID token:
+
+1. sem sessão → `Navigate` para `/users/login`
+2. com sessão e sem ID token → renova, mostrando `<Loading />`
+3. com ID token → renderiza os filhos
+
+Sem o estado 2, a primeira chamada de toda tela privada nasceria 401.
+
+---
+
+## 5. Telas
+
+### 5.1 `views/LoginPage.tsx` — reescrito
+
+Duas etapas, com estado local `"email" | "code"`:
+
+1. **E-mail** — um campo, botão "Receber código". Chama `login({ email })` e
+   guarda `session` e `destination` da resposta.
+2. **Código** — mostra "Enviamos um código para `f***@e***.com`", campo de 6
+   dígitos, botão "Entrar", e um "Reenviar código" que volta à etapa 1.
+
+Sucesso: `writeSession(username, refresh_token)`, `setIdToken(...)`, navega
+para `/home/private`.
+
+O texto atual ("A autenticação ainda não foi implementada") sai. Entra um aviso
+de que a sessão dura 30 dias (D4).
+
+Como a API não distingue e-mail cadastrado de não cadastrado (D10 do spec par),
+a etapa 1 **sempre** avança para a etapa 2. Um e-mail inexistente falha só na
+etapa 2, com "código inválido". Isso é deliberado e a tela não deve tentar
+contornar.
+
+### 5.2 `views/SignUp.tsx` — reescrito
+
+Campos: `username` (máx. 20), `name`, `email`, `phone` (opcional), `city`,
+`state`, `country`. **O campo `password` sai** — não há senha.
+
+Duas etapas, como o login:
+
+1. **Formulário** → `signUp(form)` → 202 com `destination`.
+2. **Código** → `confirmSignUp({ username, code })` → 201 com os tokens.
+
+Confirmado, o usuário **já entra logado** (o `ConfirmSignUp` do Cognito devolve
+uma `Session` que a API troca por tokens). Não digita código duas vezes: grava a
+sessão e navega para `/home/private`.
+
+O `502` do spec par — conta criada mas cadastro no ERP falhou — mostra a
+mensagem da API e leva ao login mesmo assim, porque o próximo login refaz o
+provisionamento.
+
+### 5.3 `views/Account.tsx` — alterado
+
+- **Aba Perfil**: passa a consumir `GET/PUT /accounts/private` de verdade. O
+  formulário troca `first_name`/`last_name` por um campo `name` e ganha
+  `phone`. O campo `email` fica **somente leitura**: é o que autentica, e não é
+  alterável por esta tela.
+- **Aba Centrais**: `linkThing` deixa de ser `pending()`. Trata `404` (central
+  inexistente) e `409` (já vinculada a outra conta) com mensagens próprias.
+- **Aba Sensores**: `listSensorUnits` deixa de ser `pending()`;
+  `savePreferredUnit` some, e a escolha passa a gravar em `lib/prefs.ts`. A tela
+  não muda de aparência — muda o destino do dado.
+
+### 5.4 `components/Header.tsx` — alterado
+
+Já lê `readSession()` e já tem "Sair" chamando `clearSession()`. Passa a limpar
+também o ID token em memória. O resto continua igual.
+
+---
+
+## 6. `api/endpoints.ts`
+
+**Funções novas**
+
+```ts
+export function signUp(input: AccountInput): Promise<{ destination: string }>;
+export function confirmSignUp(input: { username: string; code: string }): Promise<AuthTokens>;
+export function resendCode(input: { username: string }): Promise<{ destination: string }>;
+export function login(input: { email: string }): Promise<{ session: string; destination: string }>;
+export function verifyOtp(input: { email: string; code: string; session: string }): Promise<AuthTokens>;
+export function refresh(input: { refresh_token: string; username: string }): Promise<{ id_token: string; expires_in: number }>;
+```
+
+**Saem de `pending()`**: `listSensorUnits`, `readPrivateAccount`,
+`savePrivateAccount`, `createAccount` (vira `signUp`), `linkThing`.
+
+**Sai do arquivo**: `savePreferredUnit` e o tipo `PreferredUnitInput`.
+
+**Tipos alterados**: `AccountInput` perde `password`, troca
+`first_name`/`last_name` por `name` e ganha `phone?`. `ProfileInput` e
+`PrivateAccount` fazem a mesma troca; `PrivateAccount` ganha `phone`.
+
+`PENDING_MESSAGE` e a função `pending()` **permanecem** — continuam úteis para a
+próxima rota que a API ainda não expuser.
+
+---
+
+## 7. `lib/prefs.ts`
+
+Ganha a unidade preferida por sensor, no mesmo padrão das existentes:
+
+```ts
+export function readPreferredUnit(sensorId: number): number | null;
+export function writePreferredUnit(sensorId: number, unitId: number): void;
+```
+
+Chave `unit<sensorId>`, alinhada ao `chart<sensorId>` já usado.
+
+Motivo de a preferência não ir para o servidor: das 25 tabelas do schema,
+nenhuma liga conta a unidade. `SensorsUnits` é catálogo por sensor, com um
+`isdefault` global. Criar a tabela exigiria alterar o `SENSORIANDO_CORE`, que
+está fora do escopo. Está registrado no spec par, seção 12.
+
+---
+
+## 8. Testes
+
+`vitest`, com os arquivos `*.test.ts` ao lado do módulo, como já é a prática do
+repositório.
+
+- **`session.test.ts`** (existe, reescrito): ID token não persiste no
+  `localStorage`; sessão antiga sem `refreshToken` é lida como `null`;
+  `clearSession` limpa os dois.
+- **`client.test.ts`** (existe, ampliado): header injetado só em chamada
+  autenticada; `401` renova e repete; segundo `401` limpa a sessão; **duas
+  chamadas concorrentes disparam uma renovação só**.
+- **`endpoints.test.ts`** (existe, ampliado): as seis funções novas montando
+  método, caminho e corpo certos.
+- **`prefs.test.ts`** (existe, ampliado): unidade preferida, incluindo valor
+  ausente e valor inválido no `localStorage`.
+- **Telas**: login em duas etapas; cadastro que confirma e entra logado; perfil
+  com `email` somente leitura.
+
+---
+
+## 9. Ordem de entrega
+
+Espelha as três fases do spec par.
+
+1. **Autenticação** — `session.ts`, `client.ts`, `AuthGate.tsx`,
+   `LoginPage.tsx`, `SignUp.tsx`, `Header.tsx`, e as seis funções de
+   `endpoints.ts`.
+2. **O corte** — nenhuma mudança neste repositório. É o deploy do authorizer no
+   lado da API.
+3. **Conta** — `Account.tsx` nas três abas, `prefs.ts`, e as rotas de conta
+   saindo de `pending()`.
+
+**A ordem de deploy é obrigatória**: API fase 1 → **este repositório fase 1** →
+API fase 2. Publicar o authorizer antes do frontend novo derruba todas as telas
+privadas.
+
+---
+
+## 10. Fora de escopo
+
+- Alterar `email` ou `username` depois do cadastro.
+- Recuperação de conta por outro canal. Sem senha não há "esqueci a senha":
+  quem perde o e-mail perde a conta.
+- Login federado, passkeys, SMS.
+- Cookie `HttpOnly` para o refresh token: exigiria pôr a API atrás do mesmo
+  CloudFront do SPA, que hoje são domínios distintos. Mudança de infra
+  descartada para este trabalho.
+
+---
+
+## 11. Riscos
+
+| Risco | Mitigação |
+|---|---|
+| Refresh token em `localStorage` é alcançável por XSS | O ID token, que dá acesso imediato, não é persistido. `stacks.md` já proíbe `eval()` e `new Function()` em `web/`. |
+| Renovação concorrente | Promessa compartilhada, com teste dedicado (D5). |
+| Sessão de 30 dias expirando no meio do uso | O `client.ts` trata o `401` da renovação levando ao login com mensagem clara, não com erro genérico. |
+| Usuário fecha a aba entre cadastro e código | O código chega por e-mail e o `username` está no formulário; ele reabre o cadastro e usa "Reenviar código". Nenhum dado se perde: os atributos ficam no Cognito até a confirmação. |
+
+---
+
+## 12. Documentação a atualizar
+
+- `docs/guidelines/architecture.md` — o módulo `auth/` deixa de ser "portão de
+  conveniência"; descrever a renovação no `client.ts` e o novo fluxo de dados.
+- `docs/guidelines/stacks.md` — registrar que **nenhuma biblioteca foi
+  adicionada**, e por quê. Cognito entra na lista de serviços, mas como serviço
+  alcançado *pela API*, não pelo SPA.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@testing-library/dom": "10.4.1",
         "@testing-library/react": "16.3.2",
+        "@testing-library/user-event": "14.6.5",
         "@types/node": "22.20.1",
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
@@ -981,6 +982,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.5.tgz",
+      "integrity": "sha512-FhqjldLTpteueBaKflhNFlMT3+PM0O5fiBUivht6b9CZ1eesJyy7+g3Jr7XwJzt/Hip3ZG5hWwK1MX1FuDiE4w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,13 +14,69 @@
         "react-router-dom": "7.1.1"
       },
       "devDependencies": {
+        "@testing-library/dom": "10.4.1",
+        "@testing-library/react": "16.3.2",
         "@types/node": "22.20.1",
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "@vitejs/plugin-react": "5.2.0",
+        "jsdom": "30.0.1",
         "typescript": "5.9.3",
         "vite": "8.0.16",
         "vitest": "4.1.9"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -257,6 +313,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -305,6 +371,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -337,6 +556,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -520,9 +757,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -540,9 +774,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -560,9 +791,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -580,9 +808,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -600,9 +825,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -620,9 +842,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -716,6 +935,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -726,6 +993,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -975,6 +1249,39 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -996,6 +1303,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -1095,12 +1412,55 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1120,6 +1480,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1130,12 +1507,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.405",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
       "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
@@ -1217,11 +1614,82 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1392,9 +1860,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1416,9 +1881,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1440,9 +1902,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1464,9 +1923,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1544,6 +2000,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1553,6 +2019,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1602,6 +2075,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1660,6 +2146,31 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1684,6 +2195,13 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -1735,6 +2253,16 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -1775,6 +2303,19 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -1832,6 +2373,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -1876,6 +2424,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1902,6 +2496,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -2110,6 +2714,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2126,6 +2778,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "14.6.5",
     "@types/node": "22.20.1",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -17,10 +17,13 @@
     "react-router-dom": "7.1.1"
   },
   "devDependencies": {
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/react": "16.3.2",
     "@types/node": "22.20.1",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "@vitejs/plugin-react": "5.2.0",
+    "jsdom": "30.0.1",
     "typescript": "5.9.3",
     "vite": "8.0.16",
     "vitest": "4.1.9"

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -102,6 +102,37 @@ describe("apiPost", () => {
     const [, init] = fetchMock.mock.calls[0];
     expect(init.body).toBeUndefined();
   });
+
+  it("uses the message field of the error body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ message: "código inválido" }, 400)),
+    );
+
+    await expect(apiPost("/auth/verify", {})).rejects.toMatchObject({
+      status: 400,
+      message: "código inválido",
+    });
+  });
+
+  it("uses the detail field of the error body", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ detail: "algo" }, 400)));
+
+    await expect(apiPost("/accounts", {})).rejects.toMatchObject({
+      status: 400,
+      message: "algo",
+    });
+  });
+
+  it("falls back to the status line when the error body is not JSON", async () => {
+    const plain = new Response("not found", { status: 404 });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(plain));
+
+    await expect(apiPost("/missing")).rejects.toMatchObject({
+      status: 404,
+      message: "A API respondeu 404",
+    });
+  });
 });
 
 function memoryStorage(): Storage {
@@ -176,6 +207,23 @@ describe("authenticated requests", () => {
 
     await expect(authGet("/accounts/private")).resolves.toEqual({ username: "fulano" });
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("clears the session and reports SESSION_EXPIRED when the retry is also 401", async () => {
+    setIdToken("velho", 3600);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse({ id_token: "novo", expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse({}, 401));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(authGet("/accounts/private")).rejects.toMatchObject({
+      status: 401,
+      message: SESSION_EXPIRED,
+    });
+    // A fresh token was refused too: the session is gone, not just the token.
+    expect(readSession()).toBeNull();
   });
 
   it("gives up and clears the session when the refresh itself is rejected", async () => {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ApiError, apiGet, apiPost } from "./client";
+import { ApiError, SESSION_EXPIRED, apiGet, apiPost, authGet, authPost } from "./client";
+import { clearIdToken, readSession, setIdToken, writeSession } from "../auth/session";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -100,5 +101,113 @@ describe("apiPost", () => {
 
     const [, init] = fetchMock.mock.calls[0];
     expect(init.body).toBeUndefined();
+  });
+});
+
+function memoryStorage(): Storage {
+  const entries = new Map<string, string>();
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear: () => entries.clear(),
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => Array.from(entries.keys())[index] ?? null,
+    removeItem: (key: string) => void entries.delete(key),
+    setItem: (key: string, value: string) => void entries.set(key, value),
+  } as Storage;
+}
+
+describe("authenticated requests", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", memoryStorage());
+    clearIdToken();
+    writeSession("fulano", "refresh-token");
+  });
+
+  it("sends the id token as a bearer credential", async () => {
+    setIdToken("id-token", 3600);
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ username: "fulano" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await authGet("/accounts/private");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer id-token");
+  });
+
+  it("does not send a token on a public request", async () => {
+    setIdToken("id-token", 3600);
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiGet("/sensors");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers?.Authorization).toBeUndefined();
+  });
+
+  it("renews before the first call when only the refresh token survives", async () => {
+    // The state right after a page reload: the id token died with the tab.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ id_token: "novo", expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse({ username: "fulano" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await authGet("/accounts/private");
+
+    expect(fetchMock.mock.calls[0][0]).toBe("/auth/refresh");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      refresh_token: "refresh-token",
+      username: "fulano",
+    });
+    expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe("Bearer novo");
+  });
+
+  it("renews once and retries when a call comes back 401", async () => {
+    setIdToken("velho", 3600);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse({ id_token: "novo", expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse({ username: "fulano" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(authGet("/accounts/private")).resolves.toEqual({ username: "fulano" });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up and clears the session when the refresh itself is rejected", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}, 401));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(authGet("/accounts/private")).rejects.toMatchObject({
+      status: 401,
+      message: SESSION_EXPIRED,
+    });
+    // 30 days elapsed: there is nothing left to renew with.
+    expect(readSession()).toBeNull();
+  });
+
+  it("renews only once for concurrent callers", async () => {
+    // Several views mount at the same time. Without a shared promise this
+    // would fire one refresh per view.
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url === "/auth/refresh") {
+        return Promise.resolve(jsonResponse({ id_token: "novo", expires_in: 3600 }));
+      }
+      return Promise.resolve(jsonResponse([]));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await Promise.all([
+      authGet("/accounts/private"),
+      authPost("/things/private", {}),
+      authGet("/data/stats/private"),
+    ]);
+
+    const refreshes = fetchMock.mock.calls.filter(([url]) => url === "/auth/refresh");
+    expect(refreshes).toHaveLength(1);
   });
 });

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -103,24 +103,17 @@ describe("apiPost", () => {
     expect(init.body).toBeUndefined();
   });
 
-  it("uses the message field of the error body", async () => {
+  it("uses the error field of the error body, which is what the API actually sends", async () => {
+    // common/http.py's json_response wraps every BadRequest, ApiFailure and
+    // unhandled exception as {"error": "..."} -- never "message" or "detail".
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(jsonResponse({ message: "código inválido" }, 400)),
+      vi.fn().mockResolvedValue(jsonResponse({ error: "código inválido" }, 400)),
     );
 
     await expect(apiPost("/auth/verify", {})).rejects.toMatchObject({
       status: 400,
       message: "código inválido",
-    });
-  });
-
-  it("uses the detail field of the error body", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ detail: "algo" }, 400)));
-
-    await expect(apiPost("/accounts", {})).rejects.toMatchObject({
-      status: 400,
-      message: "algo",
     });
   });
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,6 +3,7 @@ import {
   clearIdToken,
   clearSession,
   getIdToken,
+  notifySessionExpired,
   readRefreshToken,
   readSession,
   setIdToken,
@@ -147,8 +148,11 @@ async function renew(baseUrl: string): Promise<string> {
   if (!response.ok) {
     // The refresh token is spent, revoked or past its 30 days. Nothing here
     // can recover the session, so it is cleared rather than left to fail
-    // again on every screen.
+    // again on every screen. notifySessionExpired() is what lets an AuthGate
+    // that already rendered its children -- this call can run well after the
+    // gate approved the screen -- learn to send the user back to login.
     clearSession();
+    notifySessionExpired();
     throw new ApiError(401, SESSION_EXPIRED);
   }
 
@@ -193,9 +197,11 @@ async function authenticated<T>(
       return await request<T>(method, path, body, baseUrl, renewed);
     } catch (retryError) {
       if (retryError instanceof ApiError && retryError.status === 401) {
-        // The fresh token was refused too: the session is gone. Clear it so
-        // the AuthGate sends the user to login instead of failing everywhere.
+        // The fresh token was refused too: the session is gone. Clear it and
+        // notify so the AuthGate already showing this screen sends the user
+        // to login instead of leaving them on a dead screen.
         clearSession();
+        notifySessionExpired();
         throw new ApiError(401, SESSION_EXPIRED);
       }
       throw retryError;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -37,6 +37,19 @@ function buildUrl(path: string, baseUrl: string): string {
   return `${baseUrl.replace(/\/$/, "")}${path}`;
 }
 
+// The server explains its refusal in the error body ("código inválido", a 502
+// provisioning message, ...). That text is what the user should see, so it is
+// pulled out when present; a body that is empty or not JSON falls back to the
+// status line.
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = JSON.parse(await response.text());
+    return body?.message ?? body?.detail ?? `A API respondeu ${response.status}`;
+  } catch {
+    return `A API respondeu ${response.status}`;
+  }
+}
+
 async function request<T>(
   method: "GET" | "POST" | "PUT",
   path: string,
@@ -67,7 +80,8 @@ async function request<T>(
   }
 
   if (!response.ok) {
-    throw new ApiError(response.status, `A API respondeu ${response.status}`);
+    const detail = await readErrorMessage(response);
+    throw new ApiError(response.status, detail);
   }
 
   // A 204, or any other empty body, is a valid success -- several write
@@ -175,7 +189,17 @@ async function authenticated<T>(
     // a second 401 means the problem is the session, not the token.
     clearIdToken();
     const renewed = await ensureIdToken(baseUrl);
-    return request<T>(method, path, body, baseUrl, renewed);
+    try {
+      return await request<T>(method, path, body, baseUrl, renewed);
+    } catch (retryError) {
+      if (retryError instanceof ApiError && retryError.status === 401) {
+        // The fresh token was refused too: the session is gone. Clear it so
+        // the AuthGate sends the user to login instead of failing everywhere.
+        clearSession();
+        throw new ApiError(401, SESSION_EXPIRED);
+      }
+      throw retryError;
+    }
   }
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -39,13 +39,15 @@ function buildUrl(path: string, baseUrl: string): string {
 }
 
 // The server explains its refusal in the error body ("código inválido", a 502
-// provisioning message, ...). That text is what the user should see, so it is
-// pulled out when present; a body that is empty or not JSON falls back to the
-// status line.
+// provisioning message, ...), always as {"error": "..."} -- api_handler in
+// common/http.py wraps every BadRequest, ApiFailure and unhandled exception
+// that way, never as "message" or "detail". That text is what the user should
+// see, so it is pulled out when present; a body that is empty or not JSON
+// falls back to the status line.
 async function readErrorMessage(response: Response): Promise<string> {
   try {
     const body = JSON.parse(await response.text());
-    return body?.message ?? body?.detail ?? `A API respondeu ${response.status}`;
+    return body?.error ?? `A API respondeu ${response.status}`;
   } catch {
     return `A API respondeu ${response.status}`;
   }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,4 +1,12 @@
 import { config } from "../config";
+import {
+  clearIdToken,
+  clearSession,
+  getIdToken,
+  readRefreshToken,
+  readSession,
+  setIdToken,
+} from "../auth/session";
 
 /**
  * Every failure the API layer can produce, in one shape.
@@ -17,6 +25,13 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * The message an ApiError carries when there is no way back to a session:
+ * the refresh token is gone, rejected or 30 days old. The AuthGate matches on
+ * it to send the user to the login screen instead of showing a failure.
+ */
+export const SESSION_EXPIRED = "Sua sessão expirou. Entre novamente.";
+
 function buildUrl(path: string, baseUrl: string): string {
   if (!baseUrl) return path;
   return `${baseUrl.replace(/\/$/, "")}${path}`;
@@ -27,12 +42,20 @@ async function request<T>(
   path: string,
   body: unknown,
   baseUrl: string,
+  idToken?: string,
 ): Promise<T> {
   const init: RequestInit = { method };
+  const headers: Record<string, string> = {};
 
   if (body !== undefined) {
     init.body = JSON.stringify(body);
-    init.headers = { "Content-Type": "application/json" };
+    headers["Content-Type"] = "application/json";
+  }
+  if (idToken) {
+    headers.Authorization = `Bearer ${idToken}`;
+  }
+  if (Object.keys(headers).length > 0) {
+    init.headers = headers;
   }
 
   let response: Response;
@@ -81,4 +104,97 @@ export function apiPut<T>(
   baseUrl: string = config.apiBaseUrl,
 ): Promise<T> {
   return request<T>("PUT", path, body, baseUrl);
+}
+
+// One renewal serves every caller waiting on it. Five views mounting together
+// would otherwise fire five refreshes for the same token.
+let pendingRefresh: Promise<string> | null = null;
+
+async function renew(baseUrl: string): Promise<string> {
+  const session = readSession();
+  const refreshToken = readRefreshToken();
+
+  if (!session || !refreshToken) {
+    throw new ApiError(401, SESSION_EXPIRED);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(buildUrl("/auth/refresh", baseUrl), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: refreshToken, username: session.username }),
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new ApiError(0, `Falha de conexão com a API: ${detail}`);
+  }
+
+  if (!response.ok) {
+    // The refresh token is spent, revoked or past its 30 days. Nothing here
+    // can recover the session, so it is cleared rather than left to fail
+    // again on every screen.
+    clearSession();
+    throw new ApiError(401, SESSION_EXPIRED);
+  }
+
+  const { id_token, expires_in } = (await response.json()) as {
+    id_token: string;
+    expires_in: number;
+  };
+  setIdToken(id_token, expires_in);
+
+  return id_token;
+}
+
+export function ensureIdToken(baseUrl: string = config.apiBaseUrl): Promise<string> {
+  const current = getIdToken();
+  if (current) return Promise.resolve(current);
+
+  pendingRefresh ??= renew(baseUrl).finally(() => {
+    pendingRefresh = null;
+  });
+
+  return pendingRefresh;
+}
+
+async function authenticated<T>(
+  method: "GET" | "POST" | "PUT",
+  path: string,
+  body: unknown,
+  baseUrl: string,
+): Promise<T> {
+  const token = await ensureIdToken(baseUrl);
+
+  try {
+    return await request<T>(method, path, body, baseUrl, token);
+  } catch (error) {
+    if (!(error instanceof ApiError) || error.status !== 401) throw error;
+
+    // The token was refused mid-session. Exactly one retry with a fresh one:
+    // a second 401 means the problem is the session, not the token.
+    clearIdToken();
+    const renewed = await ensureIdToken(baseUrl);
+    return request<T>(method, path, body, baseUrl, renewed);
+  }
+}
+
+export function authGet<T>(path: string, baseUrl: string = config.apiBaseUrl): Promise<T> {
+  return authenticated<T>("GET", path, undefined, baseUrl);
+}
+
+export function authPost<T>(
+  path: string,
+  body?: unknown,
+  baseUrl: string = config.apiBaseUrl,
+): Promise<T> {
+  return authenticated<T>("POST", path, body, baseUrl);
+}
+
+export function authPut<T>(
+  path: string,
+  body?: unknown,
+  baseUrl: string = config.apiBaseUrl,
+): Promise<T> {
+  return authenticated<T>("PUT", path, body, baseUrl);
 }

--- a/web/src/api/endpoints.test.ts
+++ b/web/src/api/endpoints.test.ts
@@ -1,13 +1,29 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { setIdToken, writeSession } from "../auth/session";
 import {
   confirmSignUp,
   listSensors,
   listSensorUnits,
   login,
+  savePrivateAccount,
   signUp,
   verifyOtp,
 } from "./endpoints";
+
+function memoryStorage(): Storage {
+  const entries = new Map<string, string>();
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear: () => entries.clear(),
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => Array.from(entries.keys())[index] ?? null,
+    removeItem: (key: string) => void entries.delete(key),
+    setItem: (key: string, value: string) => void entries.set(key, value),
+  } as Storage;
+}
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -92,5 +108,63 @@ describe("identity endpoints", () => {
     await verifyOtp({ email: "fulano@example.com", code: "123456", session: "s" });
 
     expect(fetchMock.mock.calls[0][0]).toBe("/auth/verify");
+  });
+
+  it("normalizes the phone to E.164 before signing up", async () => {
+    // A phone with no country code is what Cognito rejected with
+    // "Invalid phone number format." -- this is the field the form leaves
+    // unformatted, so it is normalized here rather than trusted as typed.
+    const fetchMock = vi.fn().mockResolvedValue(respond({ destination: "d" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await signUp({
+      username: "fulano",
+      name: "Fulano de Tal",
+      email: "fulano@example.com",
+      phone: "(16) 99999-1234",
+      city: "Ribeirão Preto",
+      state: "SP",
+      country: "BR",
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).phone).toBe("+5516999991234");
+  });
+});
+
+describe("saving the profile", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", memoryStorage());
+    writeSession("fulano", "refresh-token");
+    setIdToken("id-token", 3600);
+  });
+
+  it("normalizes the phone to E.164 before saving", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await savePrivateAccount({
+      name: "Fulano de Tal",
+      phone: "16999991234",
+      city: "Ribeirão Preto",
+      state: "SP",
+      country: "BR",
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).phone).toBe("+5516999991234");
+  });
+
+  it("leaves no phone as no phone", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await savePrivateAccount({
+      name: "Fulano de Tal",
+      phone: "",
+      city: "Ribeirão Preto",
+      state: "SP",
+      country: "BR",
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).phone).toBe("");
   });
 });

--- a/web/src/api/endpoints.test.ts
+++ b/web/src/api/endpoints.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ApiError } from "./client";
-import { PENDING_MESSAGE, listSensors, listSensorUnits, readPrivateAccount } from "./endpoints";
+import {
+  confirmSignUp,
+  listSensors,
+  listSensorUnits,
+  login,
+  signUp,
+  verifyOtp,
+} from "./endpoints";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -22,36 +28,6 @@ describe("existing endpoints", () => {
     await expect(listSensors()).resolves.toEqual([{ id: 1, name: "temp" }]);
     expect(fetchMock.mock.calls[0][0]).toBe("/sensors");
   });
-});
-
-describe("pending endpoints", () => {
-  it("turns a 404 into the pending message", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(respond({}, 404)));
-
-    await expect(listSensorUnits()).rejects.toMatchObject({
-      status: 404,
-      message: PENDING_MESSAGE,
-    });
-  });
-
-  it("turns a 403 into the pending message too, matching API Gateway's response for an unwired route", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(respond({}, 403)));
-
-    await expect(listSensorUnits()).rejects.toMatchObject({
-      status: 403,
-      message: PENDING_MESSAGE,
-    });
-  });
-
-  it("leaves other failures untouched", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(respond({}, 500)));
-
-    const error = await readPrivateAccount().catch((caught: unknown) => caught);
-
-    expect(error).toBeInstanceOf(ApiError);
-    expect((error as ApiError).status).toBe(500);
-    expect((error as ApiError).message).not.toBe(PENDING_MESSAGE);
-  });
 
   it("passes a successful response straight through once the route exists", async () => {
     vi.stubGlobal(
@@ -60,5 +36,61 @@ describe("pending endpoints", () => {
     );
 
     await expect(listSensorUnits()).resolves.toHaveLength(1);
+  });
+});
+
+describe("identity endpoints", () => {
+  it("posts the registration without a password", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(respond({ destination: "f***@e***.com" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await signUp({
+      username: "fulano",
+      name: "Fulano de Tal",
+      email: "fulano@example.com",
+      city: "Ribeirão Preto",
+      state: "SP",
+      country: "BR",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/accounts");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).not.toHaveProperty("password");
+  });
+
+  it("confirms the registration by username and code", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      respond({ username: "fulano", id_token: "id", refresh_token: "r", expires_in: 3600 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(confirmSignUp({ username: "fulano", code: "123456" })).resolves.toMatchObject({
+      id_token: "id",
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe("/accounts/confirm");
+  });
+
+  it("starts a sign-in with the e-mail alone", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(respond({ session: "s", destination: "d" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await login({ email: "fulano@example.com" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe("/auth/login");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      email: "fulano@example.com",
+    });
+  });
+
+  it("answers the challenge with the code and the session", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      respond({ username: "fulano", id_token: "id", refresh_token: "r", expires_in: 3600 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await verifyOtp({ email: "fulano@example.com", code: "123456", session: "s" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe("/auth/verify");
   });
 });

--- a/web/src/api/endpoints.ts
+++ b/web/src/api/endpoints.ts
@@ -141,7 +141,7 @@ export function readPrivateStats(): Promise<Stats> {
   return authGet<Stats>("/data/stats/private");
 }
 
-// --- Routes the API still has to expose -------------------------------------
+// --- Account and catalogue routes -------------------------------------------
 
 export function listSensorUnits(): Promise<SensorUnit[]> {
   return apiGet<SensorUnit[]>("/sensors/units");

--- a/web/src/api/endpoints.ts
+++ b/web/src/api/endpoints.ts
@@ -1,5 +1,6 @@
 import { ApiError, apiGet, apiPost, authGet, authPost, authPut } from "./client";
 import type { Reading, Sensor, SensorTag, SensorUnit, Stats, Thing } from "./types";
+import { normalizePhone } from "../lib/phone";
 
 /**
  * Shown when a route this app already calls does not exist in the API yet.
@@ -78,7 +79,13 @@ export interface AuthTokens {
 // authentication library and the build injects no pool or client id.
 
 export function signUp(input: AccountInput): Promise<{ destination: string }> {
-  return apiPost<{ destination: string }>("/accounts", input);
+  // Cognito's phone_number attribute requires E.164; a number typed with no
+  // country code ("16999991234") is what produced a 400 with no explanation
+  // of which field was wrong. The form is Brazil-only, so this is safe here.
+  return apiPost<{ destination: string }>("/accounts", {
+    ...input,
+    phone: input.phone !== undefined ? normalizePhone(input.phone) : input.phone,
+  });
 }
 
 // Takes the username, not the e-mail: the user has just chosen it in the form,
@@ -152,7 +159,10 @@ export function readPrivateAccount(): Promise<PrivateAccount> {
 }
 
 export function savePrivateAccount(input: ProfileInput): Promise<void> {
-  return authPut<void>("/accounts/private", input);
+  return authPut<void>("/accounts/private", {
+    ...input,
+    phone: input.phone !== undefined ? normalizePhone(input.phone) : input.phone,
+  });
 }
 
 export function linkThing(input: { uuid: string }): Promise<void> {

--- a/web/src/api/endpoints.ts
+++ b/web/src/api/endpoints.ts
@@ -1,4 +1,4 @@
-import { ApiError, apiGet, apiPost, apiPut } from "./client";
+import { ApiError, apiGet, apiPost, authGet, authPost, authPut } from "./client";
 import type { Reading, Sensor, SensorTag, SensorUnit, Stats, Thing } from "./types";
 
 /**
@@ -20,7 +20,7 @@ const PENDING_STATUSES = new Set([403, 404]);
  * from such a route is not an error worth a stack trace; anything else passes
  * through untouched so real failures stay visible.
  */
-async function pending<T>(call: () => Promise<T>): Promise<T> {
+export async function pending<T>(call: () => Promise<T>): Promise<T> {
   try {
     return await call();
   } catch (error) {
@@ -43,38 +43,72 @@ export interface DetailQuery {
 
 export interface AccountInput {
   username: string;
-  first_name: string;
-  last_name: string;
+  name: string;
   email: string;
-  password: string;
+  phone?: string;
   city: string;
   state: string;
   country: string;
 }
 
 export interface ProfileInput {
-  first_name: string;
-  last_name: string;
-  email: string;
+  name: string;
+  phone?: string;
   city: string;
   state: string;
   country: string;
 }
 
-export interface PreferredUnitInput {
-  id_sensor: number;
-  id_unit: number;
-  precision: number;
-}
-
-export interface PrivateAccount {
+export interface PrivateAccount extends ProfileInput {
   username: string;
-  first_name: string;
-  last_name: string;
   email: string;
-  city: string;
-  state: string;
-  country: string;
+}
+
+export interface AuthTokens {
+  username: string;
+  id_token: string;
+  refresh_token: string;
+  expires_in: number;
+}
+
+// --- Identity ---------------------------------------------------------------
+//
+// The browser never talks to Cognito: every one of these is an endpoint of the
+// API, which brokers the conversation. That is why this app carries no
+// authentication library and the build injects no pool or client id.
+
+export function signUp(input: AccountInput): Promise<{ destination: string }> {
+  return apiPost<{ destination: string }>("/accounts", input);
+}
+
+// Takes the username, not the e-mail: the user has just chosen it in the form,
+// and the API does not have to resolve an alias to confirm the account.
+export function confirmSignUp(input: {
+  username: string;
+  code: string;
+}): Promise<AuthTokens> {
+  return apiPost<AuthTokens>("/accounts/confirm", input);
+}
+
+export function resendCode(input: { username: string }): Promise<{ destination: string }> {
+  return apiPost<{ destination: string }>("/accounts/code", input);
+}
+
+// The answer looks the same whether or not the address is registered: the pool
+// runs with PreventUserExistenceErrors so this cannot be used to find out who
+// has an account. An unknown address only fails at verifyOtp.
+export function login(input: {
+  email: string;
+}): Promise<{ session: string; destination: string }> {
+  return apiPost<{ session: string; destination: string }>("/auth/login", input);
+}
+
+export function verifyOtp(input: {
+  email: string;
+  code: string;
+  session: string;
+}): Promise<AuthTokens> {
+  return apiPost<AuthTokens>("/auth/verify", input);
 }
 
 // --- Routes that exist ------------------------------------------------------
@@ -92,7 +126,7 @@ export function listPublicThings(filters: ThingFilters = {}): Promise<Thing[]> {
 }
 
 export function listPrivateThings(filters: ThingFilters = {}): Promise<Thing[]> {
-  return apiPost<Thing[]>("/things/private", filters);
+  return authPost<Thing[]>("/things/private", filters);
 }
 
 export function readPublicDetail(query: DetailQuery): Promise<Reading[]> {
@@ -100,35 +134,27 @@ export function readPublicDetail(query: DetailQuery): Promise<Reading[]> {
 }
 
 export function readPrivateDetail(query: DetailQuery): Promise<Reading[]> {
-  return apiPost<Reading[]>("/data/detail/private", query);
+  return authPost<Reading[]>("/data/detail/private", query);
 }
 
 export function readPrivateStats(): Promise<Stats> {
-  return apiGet<Stats>("/data/stats/private");
+  return authGet<Stats>("/data/stats/private");
 }
 
 // --- Routes the API still has to expose -------------------------------------
 
 export function listSensorUnits(): Promise<SensorUnit[]> {
-  return pending(() => apiGet<SensorUnit[]>("/sensors/units"));
-}
-
-export function savePreferredUnit(input: PreferredUnitInput): Promise<void> {
-  return pending(() => apiPut<void>("/accounts/private/sensors/units", input));
+  return apiGet<SensorUnit[]>("/sensors/units");
 }
 
 export function readPrivateAccount(): Promise<PrivateAccount> {
-  return pending(() => apiGet<PrivateAccount>("/accounts/private"));
+  return authGet<PrivateAccount>("/accounts/private");
 }
 
 export function savePrivateAccount(input: ProfileInput): Promise<void> {
-  return pending(() => apiPut<void>("/accounts/private", input));
-}
-
-export function createAccount(input: AccountInput): Promise<void> {
-  return pending(() => apiPost<void>("/accounts", input));
+  return authPut<void>("/accounts/private", input);
 }
 
 export function linkThing(input: { uuid: string }): Promise<void> {
-  return pending(() => apiPost<void>("/accounts/private/things", input));
+  return authPost<void>("/accounts/private/things", input);
 }

--- a/web/src/auth/AuthGate.test.tsx
+++ b/web/src/auth/AuthGate.test.tsx
@@ -1,17 +1,25 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import AuthGate from "./AuthGate";
 
-vi.mock("./session", () => ({ readSession: vi.fn() }));
+vi.mock("./session", () => ({ readSession: vi.fn(), onSessionExpired: vi.fn() }));
 vi.mock("../api/client", () => ({
   ensureIdToken: vi.fn(),
   SESSION_EXPIRED: "Sua sessão expirou. Entre novamente.",
 }));
 
 import { ensureIdToken } from "../api/client";
-import { readSession } from "./session";
+import { onSessionExpired, readSession } from "./session";
+
+// Reads the state a <Navigate> handed the login route, so a test can tell a
+// plain denial (no message) apart from one that followed an expiry.
+function LoginPlaceholder() {
+  const location = useLocation();
+  const message = (location.state as { message?: string } | null)?.message;
+  return <p>tela de login{message ? `: ${message}` : ""}</p>;
+}
 
 function renderGate() {
   return render(
@@ -25,7 +33,7 @@ function renderGate() {
             </AuthGate>
           }
         />
-        <Route path="/users/login" element={<p>tela de login</p>} />
+        <Route path="/users/login" element={<LoginPlaceholder />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -34,6 +42,7 @@ function renderGate() {
 beforeEach(() => {
   vi.mocked(readSession).mockReset();
   vi.mocked(ensureIdToken).mockReset();
+  vi.mocked(onSessionExpired).mockReset().mockReturnValue(() => {});
 });
 
 describe("AuthGate", () => {
@@ -63,5 +72,30 @@ describe("AuthGate", () => {
     renderGate();
 
     await waitFor(() => expect(screen.getByText("tela de login")).toBeTruthy());
+  });
+
+  it("sends an already-allowed screen to login when the session expires mid-use", async () => {
+    // A private screen's own request can fail long after AuthGate let it
+    // through -- the refresh token can expire, or the API can reject it. This
+    // is client.ts's client-side signal for that, since nothing else tells an
+    // already-rendered AuthGate.
+    vi.mocked(readSession).mockReturnValue({ username: "fulano" });
+    vi.mocked(ensureIdToken).mockResolvedValue("id-token");
+    let expiredListener: (() => void) | undefined;
+    vi.mocked(onSessionExpired).mockImplementation((listener) => {
+      expiredListener = listener;
+      return () => {};
+    });
+
+    renderGate();
+    await waitFor(() => expect(screen.getByText("conteúdo privado")).toBeTruthy());
+
+    expiredListener?.();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("tela de login: Sua sessão expirou. Entre novamente."),
+      ).toBeTruthy(),
+    );
   });
 });

--- a/web/src/auth/AuthGate.test.tsx
+++ b/web/src/auth/AuthGate.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AuthGate from "./AuthGate";
+
+vi.mock("./session", () => ({ readSession: vi.fn() }));
+vi.mock("../api/client", () => ({
+  ensureIdToken: vi.fn(),
+  SESSION_EXPIRED: "Sua sessão expirou. Entre novamente.",
+}));
+
+import { ensureIdToken } from "../api/client";
+import { readSession } from "./session";
+
+function renderGate() {
+  return render(
+    <MemoryRouter initialEntries={["/home/private"]}>
+      <Routes>
+        <Route
+          path="/home/private"
+          element={
+            <AuthGate>
+              <p>conteúdo privado</p>
+            </AuthGate>
+          }
+        />
+        <Route path="/users/login" element={<p>tela de login</p>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(readSession).mockReset();
+  vi.mocked(ensureIdToken).mockReset();
+});
+
+describe("AuthGate", () => {
+  it("sends an anonymous visitor to the login screen", () => {
+    vi.mocked(readSession).mockReturnValue(null);
+
+    renderGate();
+
+    expect(screen.getByText("tela de login")).toBeTruthy();
+  });
+
+  it("renews before rendering, because the id token died with the tab", async () => {
+    // Without this the first request of every private screen would be a 401.
+    vi.mocked(readSession).mockReturnValue({ username: "fulano" });
+    vi.mocked(ensureIdToken).mockResolvedValue("id-token");
+
+    renderGate();
+
+    await waitFor(() => expect(screen.getByText("conteúdo privado")).toBeTruthy());
+    expect(ensureIdToken).toHaveBeenCalled();
+  });
+
+  it("sends the user to the login screen when the renewal fails", async () => {
+    vi.mocked(readSession).mockReturnValue({ username: "fulano" });
+    vi.mocked(ensureIdToken).mockRejectedValue(new Error("expired"));
+
+    renderGate();
+
+    await waitFor(() => expect(screen.getByText("tela de login")).toBeTruthy());
+  });
+});

--- a/web/src/auth/AuthGate.tsx
+++ b/web/src/auth/AuthGate.tsx
@@ -2,8 +2,8 @@ import { type ReactNode, useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 
 import Loading from "../components/Loading";
-import { ensureIdToken } from "../api/client";
-import { readSession } from "./session";
+import { ensureIdToken, SESSION_EXPIRED } from "../api/client";
+import { onSessionExpired, readSession } from "./session";
 
 interface Props {
   children: ReactNode;
@@ -18,11 +18,18 @@ type Status = "checking" | "allowed" | "denied";
  * reload leaves a valid session with no token at all -- and rendering the
  * children in that state would make the first request of every screen a 401.
  * The gate renews first and only then lets them through.
+ *
+ * Letting a screen through is not the end of the story: the refresh token can
+ * still expire, or the API can still reject it, while the screen is already
+ * open. client.ts calls notifySessionExpired() when that happens, which is
+ * how an AuthGate that already rendered its children learns to send the user
+ * back to login instead of leaving them on a screen that keeps failing.
  */
 export default function AuthGate({ children }: Props) {
   const [status, setStatus] = useState<Status>(() =>
     readSession() ? "checking" : "denied",
   );
+  const [deniedReason, setDeniedReason] = useState<string | null>(null);
 
   useEffect(() => {
     if (status !== "checking") return;
@@ -44,8 +51,25 @@ export default function AuthGate({ children }: Props) {
     };
   }, [status]);
 
+  useEffect(() => {
+    if (status !== "allowed") return;
+
+    return onSessionExpired(() => {
+      setDeniedReason(SESSION_EXPIRED);
+      setStatus("denied");
+    });
+  }, [status]);
+
   if (status === "checking") return <Loading />;
-  if (status === "denied") return <Navigate to="/users/login" replace />;
+  if (status === "denied") {
+    return (
+      <Navigate
+        to="/users/login"
+        replace
+        state={deniedReason ? { message: deniedReason } : undefined}
+      />
+    );
+  }
 
   return <>{children}</>;
 }

--- a/web/src/auth/AuthGate.tsx
+++ b/web/src/auth/AuthGate.tsx
@@ -1,12 +1,51 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 
+import Loading from "../components/Loading";
+import { ensureIdToken } from "../api/client";
 import { readSession } from "./session";
 
 interface Props {
   children: ReactNode;
 }
 
+type Status = "checking" | "allowed" | "denied";
+
+/**
+ * The gate in front of every private screen.
+ *
+ * It cannot decide synchronously any more. The id token lives in memory, so a
+ * reload leaves a valid session with no token at all -- and rendering the
+ * children in that state would make the first request of every screen a 401.
+ * The gate renews first and only then lets them through.
+ */
 export default function AuthGate({ children }: Props) {
-  return readSession() ? <>{children}</> : <Navigate to="/users/login" replace />;
+  const [status, setStatus] = useState<Status>(() =>
+    readSession() ? "checking" : "denied",
+  );
+
+  useEffect(() => {
+    if (status !== "checking") return;
+
+    let active = true;
+    ensureIdToken()
+      .then(() => {
+        if (active) setStatus("allowed");
+      })
+      .catch(() => {
+        // The refresh token is gone or past its 30 days. clearSession has
+        // already run inside the client; there is nothing to do but ask for
+        // the OTP again.
+        if (active) setStatus("denied");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [status]);
+
+  if (status === "checking") return <Loading />;
+  if (status === "denied") return <Navigate to="/users/login" replace />;
+
+  return <>{children}</>;
 }

--- a/web/src/auth/session.test.ts
+++ b/web/src/auth/session.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { clearSession, readSession, writeSession } from "./session";
+import {
+  clearIdToken,
+  clearSession,
+  getIdToken,
+  readRefreshToken,
+  readSession,
+  setIdToken,
+  writeSession,
+} from "./session";
 
 function memoryStorage(): Storage {
   const entries = new Map<string, string>();
@@ -18,6 +26,7 @@ function memoryStorage(): Storage {
 
 beforeEach(() => {
   vi.stubGlobal("localStorage", memoryStorage());
+  clearIdToken();
 });
 
 describe("session", () => {
@@ -26,14 +35,19 @@ describe("session", () => {
   });
 
   it("returns the session that was written", () => {
-    writeSession("visitante");
-    expect(readSession()).toEqual({ username: "visitante" });
+    writeSession("fulano", "refresh-token");
+    expect(readSession()).toEqual({ username: "fulano" });
+    expect(readRefreshToken()).toBe("refresh-token");
   });
 
-  it("clears the session", () => {
-    writeSession("visitante");
+  it("clears both the session and the token in memory", () => {
+    writeSession("fulano", "refresh-token");
+    setIdToken("id-token", 3600);
+
     clearSession();
+
     expect(readSession()).toBeNull();
+    expect(getIdToken()).toBeNull();
   });
 
   it("treats a corrupted entry as no session instead of crashing", () => {
@@ -41,8 +55,32 @@ describe("session", () => {
     expect(readSession()).toBeNull();
   });
 
-  it("treats an entry without a username as no session", () => {
-    localStorage.setItem("sensoriando.session", JSON.stringify({ other: 1 }));
+  it("rejects a session left by the old convenience gate", () => {
+    // It carried a username and no refresh token: it never authenticated
+    // anyone, so it must not be honoured as a session now.
+    localStorage.setItem("sensoriando.session", JSON.stringify({ username: "visitante" }));
     expect(readSession()).toBeNull();
+  });
+});
+
+describe("the id token", () => {
+  it("never reaches localStorage", () => {
+    writeSession("fulano", "refresh-token");
+    setIdToken("id-token", 3600);
+
+    const stored = localStorage.getItem("sensoriando.session") ?? "";
+    expect(stored).not.toContain("id-token");
+    expect(getIdToken()).toBe("id-token");
+  });
+
+  it("is treated as absent once it is close to expiring", () => {
+    setIdToken("id-token", 30);
+    expect(getIdToken()).toBeNull();
+  });
+
+  it("is dropped by clearIdToken", () => {
+    setIdToken("id-token", 3600);
+    clearIdToken();
+    expect(getIdToken()).toBeNull();
   });
 });

--- a/web/src/auth/session.ts
+++ b/web/src/auth/session.ts
@@ -32,6 +32,24 @@ interface StoredSession {
 let idToken: string | null = null;
 let idTokenExpiresAt = 0;
 
+// Lets an AuthGate that already let a screen through learn that the session
+// it approved just failed -- the refresh token expired, or the API rejected
+// it mid-use. client.ts is the only caller: it notifies right after a 401
+// that survives a retry clears the session. A manual "Sair" does not go
+// through this -- Header already navigates on its own, and showing "your
+// session expired" after a voluntary sign-out would be a false explanation.
+type Listener = () => void;
+const expiredListeners = new Set<Listener>();
+
+export function onSessionExpired(listener: Listener): () => void {
+  expiredListeners.add(listener);
+  return () => expiredListeners.delete(listener);
+}
+
+export function notifySessionExpired(): void {
+  expiredListeners.forEach((listener) => listener());
+}
+
 function readStored(): StoredSession | null {
   const stored = localStorage.getItem(SESSION_KEY);
   if (!stored) return null;

--- a/web/src/auth/session.ts
+++ b/web/src/auth/session.ts
@@ -1,37 +1,82 @@
 /**
- * A convenience gate, not a security boundary.
+ * The signed-in user, and the two tokens that keep them signed in.
  *
- * The app is a static bundle: there is no server here to verify anything, and
- * any password shipped in it would be readable by anyone with the URL. So there
- * is no password at all — the gate only keeps the private screens out of the
- * way until real authentication (Cognito) lands.
+ * The ID token -- the one that opens every private route -- lives only in this
+ * module's memory and dies with the tab. Persisting it would leave the
+ * credential that grants immediate access sitting in storage for its whole
+ * hour; keeping it here narrows that window to the page's lifetime.
  *
- * It also grants no access to data: the API's /private endpoints serve the one
- * account named by PRIVATE_ACCOUNT_USERNAME regardless of who signed in here.
+ * The refresh token does persist, because a session that ended on every reload
+ * would be unusable. It buys nothing on its own: it has to be exchanged at
+ * POST /auth/refresh before anything can be read.
+ *
+ * Cognito issues it for 30 days and does not rotate it, so the window does not
+ * slide -- 30 days after signing in, the user does the OTP again.
  */
 
 const SESSION_KEY = "sensoriando.session";
+
+// A token that expires while the request is still in flight costs a round trip
+// and a retry. Renewing a minute early costs nothing.
+const EXPIRY_SLACK_MS = 60_000;
 
 export interface Session {
   username: string;
 }
 
-export function readSession(): Session | null {
+interface StoredSession {
+  username: string;
+  refreshToken: string;
+}
+
+let idToken: string | null = null;
+let idTokenExpiresAt = 0;
+
+function readStored(): StoredSession | null {
   const stored = localStorage.getItem(SESSION_KEY);
   if (!stored) return null;
 
   try {
-    const parsed = JSON.parse(stored) as Partial<Session>;
-    return typeof parsed.username === "string" ? { username: parsed.username } : null;
+    const parsed = JSON.parse(stored) as Partial<StoredSession>;
+    // A session written by the old convenience gate has a username and no
+    // refresh token. It never authenticated anyone, so it is not a session.
+    return typeof parsed.username === "string" && typeof parsed.refreshToken === "string"
+      ? { username: parsed.username, refreshToken: parsed.refreshToken }
+      : null;
   } catch {
     return null;
   }
 }
 
-export function writeSession(username: string): void {
-  localStorage.setItem(SESSION_KEY, JSON.stringify({ username }));
+export function readSession(): Session | null {
+  const stored = readStored();
+  return stored ? { username: stored.username } : null;
+}
+
+export function readRefreshToken(): string | null {
+  return readStored()?.refreshToken ?? null;
+}
+
+export function writeSession(username: string, refreshToken: string): void {
+  localStorage.setItem(SESSION_KEY, JSON.stringify({ username, refreshToken }));
 }
 
 export function clearSession(): void {
   localStorage.removeItem(SESSION_KEY);
+  clearIdToken();
+}
+
+export function getIdToken(): string | null {
+  if (!idToken || Date.now() >= idTokenExpiresAt - EXPIRY_SLACK_MS) return null;
+  return idToken;
+}
+
+export function setIdToken(token: string, expiresIn: number): void {
+  idToken = token;
+  idTokenExpiresAt = Date.now() + expiresIn * 1000;
+}
+
+export function clearIdToken(): void {
+  idToken = null;
+  idTokenExpiresAt = 0;
 }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -6,9 +6,9 @@ export default function Header() {
   const session = readSession();
   const navigate = useNavigate();
 
-  // clearSession only touches localStorage, which React does not observe. The
-  // navigation is what re-renders this component so the menu flips back to
-  // "Cadastrar / Entrar" instead of still showing the username.
+  // clearSession only touches localStorage and a module-level variable, and
+  // React observes neither. The reload is what makes every screen see that the
+  // session is gone.
   function signOut() {
     clearSession();
     navigate("/", { replace: true });

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -7,8 +7,9 @@ export default function Header() {
   const navigate = useNavigate();
 
   // clearSession only touches localStorage and a module-level variable, and
-  // React observes neither. The reload is what makes every screen see that the
-  // session is gone.
+  // React observes neither. The navigate() below is what makes the page see
+  // that the session is gone -- it unmounts whatever private screen was open,
+  // and Header itself re-reads readSession() on its next render.
   function signOut() {
     clearSession();
     navigate("/", { replace: true });

--- a/web/src/lib/phone.test.ts
+++ b/web/src/lib/phone.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizePhone } from "./phone";
+
+describe("normalizePhone", () => {
+  it("prepends +55 to a number typed with no country code", () => {
+    expect(normalizePhone("16999991234")).toBe("+5516999991234");
+  });
+
+  it("strips the punctuation a person naturally types", () => {
+    expect(normalizePhone("(16) 99999-1234")).toBe("+5516999991234");
+  });
+
+  it("keeps an explicit country code, only cleaning the punctuation", () => {
+    expect(normalizePhone("+55 16 99999-1234")).toBe("+5516999991234");
+  });
+
+  it("trusts a foreign country code someone typed on purpose", () => {
+    expect(normalizePhone("+1 555 123 4567")).toBe("+15551234567");
+  });
+
+  it("leaves an empty field empty -- phone is optional", () => {
+    expect(normalizePhone("")).toBe("");
+    expect(normalizePhone("   ")).toBe("");
+  });
+});

--- a/web/src/lib/phone.ts
+++ b/web/src/lib/phone.ts
@@ -1,0 +1,21 @@
+/**
+ * Normalizes a phone number to E.164, the format Cognito's `phone_number`
+ * attribute requires -- a number typed without it ("16999991234") is what
+ * produced a 400 with no explanation of which field was wrong.
+ *
+ * The signup form only ever offers Brazil as a country (see COUNTRIES in
+ * lib/locations.ts), so a number with no leading "+" is assumed Brazilian and
+ * gets "+55" prepended. A number that already starts with "+" is trusted as
+ * written, just cleaned of the punctuation a person naturally types.
+ */
+export function normalizePhone(phone: string): string {
+  const trimmed = phone.trim();
+  if (!trimmed) return "";
+
+  if (trimmed.startsWith("+")) {
+    return `+${trimmed.slice(1).replace(/\D/g, "")}`;
+  }
+
+  const digits = trimmed.replace(/\D/g, "");
+  return digits ? `+55${digits}` : "";
+}

--- a/web/src/lib/prefs.test.ts
+++ b/web/src/lib/prefs.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { readChartType, readPeriod, writeChartType, writePeriod } from "./prefs";
+import {
+  readChartType,
+  readPeriod,
+  readPreferredUnit,
+  writeChartType,
+  writePeriod,
+  writePreferredUnit,
+} from "./prefs";
 
 function memoryStorage(): Storage {
   const entries = new Map<string, string>();
@@ -58,5 +65,24 @@ describe("readChartType", () => {
   it("falls back to the default when the stored value is not a chart type", () => {
     localStorage.setItem("chart7", "pie");
     expect(readChartType(7)).toBe("line");
+  });
+});
+
+describe("preferred unit", () => {
+  it("has none until one is chosen", () => {
+    expect(readPreferredUnit(3)).toBeNull();
+  });
+
+  it("returns the unit that was chosen for that sensor", () => {
+    writePreferredUnit(3, 7);
+    writePreferredUnit(4, 9);
+
+    expect(readPreferredUnit(3)).toBe(7);
+    expect(readPreferredUnit(4)).toBe(9);
+  });
+
+  it("treats a corrupted entry as no preference", () => {
+    localStorage.setItem("unit3", "nem numero");
+    expect(readPreferredUnit(3)).toBeNull();
   });
 });

--- a/web/src/lib/prefs.ts
+++ b/web/src/lib/prefs.ts
@@ -33,3 +33,25 @@ export function readChartType(sensorId: number): ChartType {
 export function writeChartType(sensorId: number, type: ChartType): void {
   localStorage.setItem(chartTypeKey(sensorId), type);
 }
+
+const preferredUnitKey = (sensorId: number) => `unit${sensorId}`;
+
+/**
+ * Which unit this browser shows for a sensor.
+ *
+ * It is a browser preference, not an account setting: the schema has no table
+ * linking an account to a unit -- `sensorsunits` is a catalogue with a global
+ * `isdefault` -- and adding one would mean changing the Core's database. So it
+ * sits beside the period and the chart type, which are stored the same way.
+ */
+export function readPreferredUnit(sensorId: number): number | null {
+  const stored = localStorage.getItem(preferredUnitKey(sensorId));
+  if (stored === null) return null;
+
+  const parsed = Number(stored);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+export function writePreferredUnit(sensorId: number, unitId: number): void {
+  localStorage.setItem(preferredUnitKey(sensorId), String(unitId));
+}

--- a/web/src/views/Account.test.tsx
+++ b/web/src/views/Account.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/endpoints", () => ({
+  readPrivateAccount: vi.fn(),
+  savePrivateAccount: vi.fn(),
+  linkThing: vi.fn(),
+  listSensorUnits: vi.fn(),
+  listPrivateThings: vi.fn(),
+}));
+
+import Account from "./Account";
+import {
+  linkThing,
+  listPrivateThings,
+  listSensorUnits,
+  readPrivateAccount,
+  savePrivateAccount,
+} from "../api/endpoints";
+
+beforeEach(() => {
+  vi.mocked(readPrivateAccount).mockReset();
+  vi.mocked(savePrivateAccount).mockReset();
+  vi.mocked(linkThing).mockReset();
+  vi.mocked(listSensorUnits).mockReset();
+  vi.mocked(listPrivateThings).mockReset();
+});
+
+const ACCOUNT = {
+  username: "fulano",
+  name: "Fulano de Tal",
+  email: "fulano@example.com",
+  phone: "16999991234",
+  city: "Ribeirão Preto",
+  state: "SP",
+  country: "BR",
+};
+
+function renderProfile() {
+  return render(
+    <MemoryRouter initialEntries={["/users/account/fulano/profile"]}>
+      <Routes>
+        <Route path="/users/account/:username/:tab" element={<Account />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("the profile tab", () => {
+  it("shows one name field, because the ERP stores one name", async () => {
+    vi.mocked(readPrivateAccount).mockResolvedValue(ACCOUNT);
+
+    renderProfile();
+
+    await waitFor(() =>
+      expect((screen.getByLabelText(/^nome/i) as HTMLInputElement).value).toBe(
+        "Fulano de Tal",
+      ),
+    );
+    expect(screen.queryByLabelText(/sobrenome/i)).toBeNull();
+  });
+
+  it("does not let the e-mail be edited", async () => {
+    vi.mocked(readPrivateAccount).mockResolvedValue(ACCOUNT);
+
+    renderProfile();
+
+    await waitFor(() =>
+      expect((screen.getByLabelText(/e-mail/i) as HTMLInputElement).readOnly).toBe(true),
+    );
+  });
+
+  it("saves without the fields it does not own", async () => {
+    vi.mocked(readPrivateAccount).mockResolvedValue(ACCOUNT);
+    vi.mocked(savePrivateAccount).mockResolvedValue(undefined);
+
+    renderProfile();
+    await waitFor(() => screen.getByLabelText(/^nome/i));
+    await userEvent.click(screen.getByRole("button", { name: /salvar/i }));
+
+    const sent = vi.mocked(savePrivateAccount).mock.calls[0][0];
+    expect(sent).not.toHaveProperty("username");
+    expect(sent).not.toHaveProperty("email");
+  });
+});
+
+describe("the things tab", () => {
+  it("turns a 409 from linking into the expected message", async () => {
+    vi.mocked(listPrivateThings).mockResolvedValue([]);
+    vi.mocked(linkThing).mockRejectedValue(
+      Object.assign(new Error("a api respondeu 409"), { name: "ApiError", status: 409 }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/users/account/fulano/things"]}>
+        <Routes>
+          <Route path="/users/account/:username/:tab" element={<Account />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await userEvent.type(screen.getByLabelText(/nova central/i), "a-b-c-d");
+    await userEvent.click(screen.getByRole("button", { name: /adicionar/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/já pertence a uma conta/i)).toBeTruthy(),
+    );
+  });
+});

--- a/web/src/views/Account.tsx
+++ b/web/src/views/Account.tsx
@@ -8,14 +8,19 @@ import {
   listPrivateThings,
   listSensorUnits,
   readPrivateAccount,
-  savePreferredUnit,
   savePrivateAccount,
 } from "../api/endpoints";
 import type { ThingSensor } from "../api/types";
 import ErrorBanner from "../components/ErrorBanner";
 import Loading from "../components/Loading";
 import { BRAZIL_STATES, COUNTRIES } from "../lib/locations";
-import { type ChartType, readChartType, writeChartType } from "../lib/prefs";
+import {
+  type ChartType,
+  readChartType,
+  readPreferredUnit,
+  writeChartType,
+  writePreferredUnit,
+} from "../lib/prefs";
 import { useApi } from "../lib/useApi";
 
 const TABS = [
@@ -31,24 +36,31 @@ const CHART_TYPES: Array<{ value: ChartType; label: string }> = [
   { value: "display", label: "Display" },
 ];
 
-// MAX_PRECISION as the running Django code defines it in users/views.py.
-// base/constants.py carries a stale 5 that no view reads.
-const PRECISIONS = [0, 1, 2];
+// The API layer always rejects with ApiError, which marks itself with
+// name === "ApiError". Matching by name too lets the tests fabricate a failure
+// with a plain Error and still get the API message, instead of the generic one.
+function isApiError(caught: unknown): caught is { message: string; status: number } {
+  if (caught instanceof ApiError) return true;
+  if (caught instanceof Error && caught.name === "ApiError") return true;
+  return false;
+}
 
 function message(caught: unknown, fallback: string): string {
-  return caught instanceof ApiError ? caught.message : fallback;
+  return isApiError(caught) ? caught.message : fallback;
 }
 
 function ProfileTab() {
   const account = useApi(() => readPrivateAccount(), []);
   const [form, setForm] = useState<ProfileInput | null>(null);
+  const [email, setEmail] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
   useEffect(() => {
     if (account.data) {
-      const { first_name, last_name, email, city, state, country } = account.data;
-      setForm({ first_name, last_name, email, city, state, country });
+      const { name, phone, city, state, country } = account.data;
+      setForm({ name, phone, city, state, country });
+      setEmail(account.data.email);
     }
   }, [account.data]);
 
@@ -62,7 +74,11 @@ function ProfileTab() {
       await savePrivateAccount(form);
       setSaved(true);
     } catch (caught: unknown) {
-      setError(message(caught, "Falha inesperada ao salvar o perfil"));
+      if (isApiError(caught) && caught.status === 409) {
+        setError("Conta ainda não registrada. Entre novamente para concluir o cadastro.");
+      } else {
+        setError(message(caught, "Falha inesperada ao salvar o perfil"));
+      }
     }
   }
 
@@ -80,35 +96,30 @@ function ProfileTab() {
       {saved && <p className="font-17px">Perfil salvo.</p>}
 
       <p>
-        <label className="font-16px" htmlFor="first_name">
+        <label className="font-16px" htmlFor="name">
           Nome
         </label>
         <input
-          id="first_name"
-          value={form.first_name}
-          onChange={(event) => update("first_name", event.target.value)}
+          id="name"
+          value={form.name}
+          onChange={(event) => update("name", event.target.value)}
         />
       </p>
       <p>
-        <label className="font-16px" htmlFor="last_name">
-          Sobrenome
+        <label className="font-16px" htmlFor="phone">
+          Telefone
         </label>
         <input
-          id="last_name"
-          value={form.last_name}
-          onChange={(event) => update("last_name", event.target.value)}
+          id="phone"
+          value={form.phone ?? ""}
+          onChange={(event) => update("phone", event.target.value)}
         />
       </p>
       <p>
         <label className="font-16px" htmlFor="email">
           E-mail
         </label>
-        <input
-          id="email"
-          type="email"
-          value={form.email}
-          onChange={(event) => update("email", event.target.value)}
-        />
+        <input id="email" type="email" value={email} readOnly />
       </p>
       <p>
         <label className="font-16px" htmlFor="city">
@@ -153,7 +164,7 @@ function ProfileTab() {
         </select>
       </p>
 
-      <button type="submit">Alterar</button>
+      <button type="submit">Salvar</button>
     </form>
   );
 }
@@ -171,7 +182,13 @@ function ThingsTab() {
       await linkThing({ uuid });
       setUuid("");
     } catch (caught: unknown) {
-      setError(message(caught, "Falha inesperada ao vincular a central"));
+      if (isApiError(caught)) {
+        if (caught.status === 404) setError("Central não encontrada.");
+        else if (caught.status === 409) setError("Esta central já pertence a uma conta.");
+        else setError(caught.message);
+      } else {
+        setError("Falha inesperada ao vincular a central");
+      }
     }
   }
 
@@ -220,28 +237,15 @@ function ThingsTab() {
 
 function SensorRow({ sensor }: { sensor: ThingSensor; }) {
   const units = useApi(() => listSensorUnits(), []);
-  const [error, setError] = useState<string | null>(null);
-  const [unitId, setUnitId] = useState<number | null>(null);
-  const [precision, setPrecision] = useState(PRECISIONS[0]);
+  const [unitId, setUnitId] = useState<number | null>(() => readPreferredUnit(sensor.id));
 
   const sensorUnits = (units.data ?? []).filter((unit) => unit.id_sensor === sensor.id);
 
   // The chart type is presentation only, so it stays in localStorage. The unit
-  // and the precision are moving to the database, where the API can apply them
-  // before serving the value -- hence the PUT rather than a local write.
-  async function persist(nextUnitId: number | null, nextPrecision: number) {
-    if (nextUnitId === null) return;
-
-    setError(null);
-    try {
-      await savePreferredUnit({
-        id_sensor: sensor.id,
-        id_unit: nextUnitId,
-        precision: nextPrecision,
-      });
-    } catch (caught: unknown) {
-      setError(message(caught, "Falha inesperada ao salvar a preferência"));
-    }
+  // is a browser preference too, so both sit beside the period in prefs.ts.
+  function selectUnit(next: number | null) {
+    setUnitId(next);
+    if (next !== null) writePreferredUnit(sensor.id, next);
   }
 
   return (
@@ -273,8 +277,7 @@ function SensorRow({ sensor }: { sensor: ThingSensor; }) {
               // selection, not silently pick unit id 0.
               const raw = event.target.value;
               const next = raw === "" ? null : Number(raw);
-              setUnitId(next);
-              void persist(next, precision);
+              selectUnit(next);
             }}
           >
             <option value="">—</option>
@@ -286,30 +289,13 @@ function SensorRow({ sensor }: { sensor: ThingSensor; }) {
           </select>
         )}
       </td>
-
-      <td>
-        <select
-          value={precision}
-          onChange={(event) => {
-            const next = Number(event.target.value);
-            setPrecision(next);
-            void persist(unitId, next);
-          }}
-        >
-          {PRECISIONS.map((option) => (
-            <option key={option} value={option}>
-              {option}
-            </option>
-          ))}
-        </select>
-      </td>
-
-      <td>{error && <ErrorBanner message={error} />}</td>
     </tr>
   );
 }
 
 function SensorsTab() {
+  // The unit is a browser preference, not an account setting: there is no table
+  // in the schema linking an account to a unit. See lib/prefs.ts.
   const things = useApi(() => listPrivateThings(), []);
 
   // One row per distinct sensor across the account's things.
@@ -332,8 +318,6 @@ function SensorsTab() {
             <th>Sensor</th>
             <th>Gráfico</th>
             <th>Unidade</th>
-            <th>Precisão</th>
-            <th />
           </tr>
         </thead>
         <tbody>

--- a/web/src/views/LoginPage.test.tsx
+++ b/web/src/views/LoginPage.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/endpoints", () => ({ login: vi.fn(), verifyOtp: vi.fn() }));
+vi.mock("../auth/session", () => ({ writeSession: vi.fn(), setIdToken: vi.fn() }));
+
+import LoginPage from "./LoginPage";
+import { login, verifyOtp } from "../api/endpoints";
+import { setIdToken, writeSession } from "../auth/session";
+
+beforeEach(() => {
+  vi.mocked(login).mockReset();
+  vi.mocked(verifyOtp).mockReset();
+  vi.mocked(writeSession).mockReset();
+});
+
+describe("LoginPage", () => {
+  it("asks for the code only after the e-mail was submitted", async () => {
+    vi.mocked(login).mockResolvedValue({ session: "s", destination: "f***@e***.com" });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByLabelText(/código/i)).toBeNull();
+
+    await userEvent.type(screen.getByLabelText(/e-mail/i), "fulano@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /receber código/i }));
+
+    await waitFor(() => expect(screen.getByLabelText(/código/i)).toBeTruthy());
+    // The masked address tells the user which inbox to open.
+    expect(screen.getByText(/f\*\*\*@e\*\*\*\.com/)).toBeTruthy();
+  });
+
+  it("stores the session that verifying the code returns", async () => {
+    vi.mocked(login).mockResolvedValue({ session: "s", destination: "d" });
+    vi.mocked(verifyOtp).mockResolvedValue({
+      username: "fulano",
+      id_token: "id",
+      refresh_token: "refresh",
+      expires_in: 3600,
+    });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    await userEvent.type(screen.getByLabelText(/e-mail/i), "fulano@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /receber código/i }));
+    await waitFor(() => screen.getByLabelText(/código/i));
+
+    await userEvent.type(screen.getByLabelText(/código/i), "123456");
+    await userEvent.click(screen.getByRole("button", { name: /entrar/i }));
+
+    await waitFor(() =>
+      expect(writeSession).toHaveBeenCalledWith("fulano", "refresh"),
+    );
+    expect(setIdToken).toHaveBeenCalledWith("id", 3600);
+  });
+
+  it("shows the message when the code is refused", async () => {
+    vi.mocked(login).mockResolvedValue({ session: "s", destination: "d" });
+    vi.mocked(verifyOtp).mockRejectedValue(
+      Object.assign(new Error("código inválido"), { name: "ApiError", status: 400 }),
+    );
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    await userEvent.type(screen.getByLabelText(/e-mail/i), "fulano@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /receber código/i }));
+    await waitFor(() => screen.getByLabelText(/código/i));
+
+    await userEvent.type(screen.getByLabelText(/código/i), "000000");
+    await userEvent.click(screen.getByRole("button", { name: /entrar/i }));
+
+    await waitFor(() => expect(screen.getByText(/código inválido/i)).toBeTruthy());
+  });
+});

--- a/web/src/views/LoginPage.test.tsx
+++ b/web/src/views/LoginPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../api/endpoints", () => ({ login: vi.fn(), verifyOtp: vi.fn() }));
@@ -84,5 +84,23 @@ describe("LoginPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /entrar/i }));
 
     await waitFor(() => expect(screen.getByText(/código inválido/i)).toBeTruthy());
+  });
+
+  it("shows the reason AuthGate sent the user here", () => {
+    // AuthGate hands this in location.state when a session expires mid-use;
+    // otherwise the user lands here with no explanation for the redirect.
+    render(
+      <MemoryRouter
+        initialEntries={[
+          { pathname: "/users/login", state: { message: "Sua sessão expirou. Entre novamente." } },
+        ]}
+      >
+        <Routes>
+          <Route path="/users/login" element={<LoginPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Sua sessão expirou. Entre novamente.")).toBeTruthy();
   });
 });

--- a/web/src/views/LoginPage.tsx
+++ b/web/src/views/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { ApiError } from "../api/client";
 import { login, verifyOtp } from "../api/endpoints";
@@ -25,12 +25,18 @@ function apiMessage(caught: unknown): string {
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  // AuthGate hands this in when a session expires mid-use and it redirects
+  // here on its own: without it the user lands on a blank login form with no
+  // explanation for why they were signed out.
+  const location = useLocation();
   const [step, setStep] = useState<"email" | "code">("email");
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
   const [session, setSession] = useState("");
   const [destination, setDestination] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(
+    (location.state as { message?: string } | null)?.message ?? null,
+  );
   const [sending, setSending] = useState(false);
 
   async function requestCode(event: FormEvent) {

--- a/web/src/views/LoginPage.tsx
+++ b/web/src/views/LoginPage.tsx
@@ -1,15 +1,70 @@
+import { type FormEvent, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { writeSession } from "../auth/session";
+import { ApiError } from "../api/client";
+import { login, verifyOtp } from "../api/endpoints";
+import { setIdToken, writeSession } from "../auth/session";
+import ErrorBanner from "../components/ErrorBanner";
 
-const GUEST_USERNAME = "visitante";
+// The API layer always rejects with ApiError, which marks itself with
+// name === "ApiError". Matching by name too lets the tests fabricate a failure
+// with a plain Error and still get the API message, instead of the generic one.
+function apiMessage(caught: unknown): string {
+  if (caught instanceof ApiError) return caught.message;
+  if (caught instanceof Error && caught.name === "ApiError") return caught.message;
+  return "Falha inesperada ao entrar";
+}
+
+/**
+ * Sign-in in two steps: an address, then the code that arrives in it.
+ *
+ * The first step always advances, even for an address with no account: the API
+ * answers the same either way, on purpose, so that this screen cannot be used
+ * to find out who is registered. An unknown address only fails at the code.
+ */
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  const [step, setStep] = useState<"email" | "code">("email");
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [session, setSession] = useState("");
+  const [destination, setDestination] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
 
-  function enter() {
-    writeSession(GUEST_USERNAME);
-    navigate("/home/private");
+  async function requestCode(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setSending(true);
+
+    try {
+      const answer = await login({ email });
+      setSession(answer.session);
+      setDestination(answer.destination);
+      setStep("code");
+    } catch (caught: unknown) {
+      setError(apiMessage(caught));
+    } finally {
+      setSending(false);
+    }
+  }
+
+  async function enter(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setSending(true);
+
+    try {
+      const tokens = await verifyOtp({ email, code, session });
+      writeSession(tokens.username, tokens.refresh_token);
+      setIdToken(tokens.id_token, tokens.expires_in);
+      navigate("/home/private");
+    } catch (caught: unknown) {
+      setError(apiMessage(caught));
+    } finally {
+      setSending(false);
+    }
   }
 
   return (
@@ -21,13 +76,62 @@ export default function LoginPage() {
       </section>
 
       <section className="signUp">
-        <p className="font-17px">
-          A autenticação ainda não foi implementada. Este acesso é temporário e serve
-          apenas para visualizar as telas privadas.
-        </p>
-        <button type="button" className="font-16px" onClick={enter}>
-          <span>Entrar</span>
-        </button>
+        {error && <ErrorBanner message={error} />}
+
+        {step === "email" ? (
+          <form onSubmit={requestCode}>
+            <p className="font-17px">
+              Enviaremos um código de acesso para o seu e-mail. Não há senha. A sessão
+              dura 30 dias.
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="email">
+                E-mail
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+              />
+            </p>
+            <button type="submit" className="font-16px" disabled={sending}>
+              <span>{sending ? "Enviando…" : "Receber código"}</span>
+            </button>
+          </form>
+        ) : (
+          <form onSubmit={enter}>
+            <p className="font-17px">
+              Enviamos um código para {destination}. Digite-o abaixo para entrar.
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="code">
+                Código
+              </label>
+              <input
+                id="code"
+                inputMode="numeric"
+                value={code}
+                onChange={(event) => setCode(event.target.value)}
+                required
+              />
+            </p>
+            <button type="submit" className="font-16px" disabled={sending}>
+              <span>{sending ? "Entrando…" : "Entrar"}</span>
+            </button>
+            <button
+              type="button"
+              className="font-16px"
+              onClick={() => {
+                setError(null);
+                setStep("email");
+              }}
+            >
+              <span>Reenviar código</span>
+            </button>
+          </form>
+        )}
       </section>
     </>
   );

--- a/web/src/views/SignUp.test.tsx
+++ b/web/src/views/SignUp.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/endpoints", () => ({
+  signUp: vi.fn(),
+  confirmSignUp: vi.fn(),
+  resendCode: vi.fn(),
+}));
+vi.mock("../auth/session", () => ({ writeSession: vi.fn(), setIdToken: vi.fn() }));
+
+import SignUp from "./SignUp";
+import { confirmSignUp, resendCode, signUp } from "../api/endpoints";
+import { writeSession } from "../auth/session";
+
+beforeEach(() => {
+  vi.mocked(signUp).mockReset();
+  vi.mocked(confirmSignUp).mockReset();
+  vi.mocked(resendCode).mockReset();
+  vi.mocked(writeSession).mockReset();
+});
+
+const FORM = {
+  username: "fulano",
+  name: "Fulano de Tal",
+  email: "fulano@example.com",
+  city: "Ribeirão Preto",
+};
+
+async function fillTheForm() {
+  await userEvent.type(screen.getByLabelText(/^usuário/i), FORM.username);
+  await userEvent.type(screen.getByLabelText(/^nome/i), FORM.name);
+  await userEvent.type(screen.getByLabelText(/e-mail/i), FORM.email);
+  await userEvent.type(screen.getByLabelText(/cidade/i), FORM.city);
+}
+
+describe("SignUp", () => {
+  it("has no password field, because the platform has no passwords", () => {
+    render(
+      <MemoryRouter>
+        <SignUp />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByLabelText(/senha/i)).toBeNull();
+  });
+
+  it("limits the username to what the column holds", () => {
+    render(
+      <MemoryRouter>
+        <SignUp />
+      </MemoryRouter>,
+    );
+
+    // accounts.username is VARCHAR(20).
+    expect(screen.getByLabelText(/^usuário/i).getAttribute("maxLength")).toBe("20");
+  });
+
+  it("signs the user in as soon as the code is confirmed", async () => {
+    vi.mocked(signUp).mockResolvedValue({ destination: "f***@e***.com" });
+    vi.mocked(confirmSignUp).mockResolvedValue({
+      username: "fulano",
+      id_token: "id",
+      refresh_token: "refresh",
+      expires_in: 3600,
+    });
+
+    render(
+      <MemoryRouter>
+        <SignUp />
+      </MemoryRouter>,
+    );
+
+    await fillTheForm();
+    await userEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
+    await waitFor(() => screen.getByLabelText(/código/i));
+
+    await userEvent.type(screen.getByLabelText(/código/i), "123456");
+    await userEvent.click(screen.getByRole("button", { name: /confirmar/i }));
+
+    // Confirming with the OTP already proves the e-mail, so Cognito hands back
+    // a session: the user never types a second code.
+    await waitFor(() => expect(writeSession).toHaveBeenCalledWith("fulano", "refresh"));
+  });
+
+  it("reports a duplicated e-mail without losing what was typed", async () => {
+    vi.mocked(signUp).mockRejectedValue(
+      Object.assign(new Error("este e-mail já tem conta"), { name: "ApiError", status: 409 }),
+    );
+
+    render(
+      <MemoryRouter>
+        <SignUp />
+      </MemoryRouter>,
+    );
+
+    await fillTheForm();
+    await userEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
+
+    await waitFor(() => expect(screen.getByText(/já tem conta/i)).toBeTruthy());
+    expect((screen.getByLabelText(/^nome/i) as HTMLInputElement).value).toBe(FORM.name);
+  });
+});

--- a/web/src/views/SignUp.tsx
+++ b/web/src/views/SignUp.tsx
@@ -1,25 +1,53 @@
 import { type FormEvent, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 
 import { ApiError } from "../api/client";
-import { createAccount } from "../api/endpoints";
+import { confirmSignUp, resendCode, signUp } from "../api/endpoints";
+import { setIdToken, writeSession } from "../auth/session";
 import ErrorBanner from "../components/ErrorBanner";
 import { BRAZIL_STATES, COUNTRIES } from "../lib/locations";
 
+// The API layer always rejects with ApiError, which marks itself with
+// name === "ApiError". Matching by name too lets the tests fabricate a failure
+// with a plain Error and still get the API message, instead of the generic one.
+function isApiError(caught: unknown): caught is { message: string; status: number } {
+  if (caught instanceof ApiError) return true;
+  if (caught instanceof Error && caught.name === "ApiError") return true;
+  return false;
+}
+
+function apiMessage(caught: unknown): string {
+  return isApiError(caught) ? caught.message : "Falha inesperada ao criar a conta";
+}
+
+/**
+ * Registration in two steps, with no password anywhere.
+ *
+ * The first step only creates the Cognito user: name, phone and address wait
+ * as attributes on it, and nothing reaches the ERP until the address is
+ * proven. The second step confirms the code -- which both verifies the e-mail
+ * and signs the user in, so they land logged in rather than at the login
+ * screen.
+ */
+
 const EMPTY = {
   username: "",
-  first_name: "",
-  last_name: "",
+  name: "",
   email: "",
-  password: "",
+  phone: "",
   city: "",
   state: BRAZIL_STATES[0].value,
   country: COUNTRIES[0].value,
 };
 
 export default function SignUp() {
+  const navigate = useNavigate();
   const [form, setForm] = useState(EMPTY);
+  const [step, setStep] = useState<"form" | "code">("form");
+  const [code, setCode] = useState("");
+  const [destination, setDestination] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [done, setDone] = useState(false);
+  const [accountExists, setAccountExists] = useState(false);
   const [sending, setSending] = useState(false);
 
   function update(field: keyof typeof EMPTY, value: string) {
@@ -29,15 +57,50 @@ export default function SignUp() {
   async function submit(event: FormEvent) {
     event.preventDefault();
     setError(null);
+    setAccountExists(false);
     setSending(true);
 
     try {
-      await createAccount(form);
-      setDone(true);
+      const answer = await signUp(form);
+      setDestination(answer.destination);
+      setStep("code");
     } catch (caught: unknown) {
-      setError(
-        caught instanceof ApiError ? caught.message : "Falha inesperada ao criar a conta",
-      );
+      setError(apiMessage(caught));
+      // A 502 means the account already exists: the e-mail was registered
+      // before, and the first login re-provisions it. Point the user there.
+      setAccountExists(isApiError(caught) && caught.status === 502);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  async function confirm(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setAccountExists(false);
+    setSending(true);
+
+    try {
+      const tokens = await confirmSignUp({ username: form.username, code });
+      writeSession(tokens.username, tokens.refresh_token);
+      setIdToken(tokens.id_token, tokens.expires_in);
+      navigate("/home/private");
+    } catch (caught: unknown) {
+      setError(apiMessage(caught));
+    } finally {
+      setSending(false);
+    }
+  }
+
+  async function resend() {
+    setError(null);
+    setAccountExists(false);
+    setSending(true);
+
+    try {
+      await resendCode({ username: form.username });
+    } catch (caught: unknown) {
+      setError(apiMessage(caught));
     } finally {
       setSending(false);
     }
@@ -53,114 +116,142 @@ export default function SignUp() {
 
       <section className="signUp">
         {error && <ErrorBanner message={error} />}
-        {done && <p className="font-17px">Conta criada.</p>}
+        {accountExists && (
+          <p className="font-17px">
+            <Link to="/users/login">Entrar na sua conta</Link>
+          </p>
+        )}
 
-        <form onSubmit={submit}>
-          <p>
-            <label className="font-17px" htmlFor="username">
-              Usuário
-            </label>
-            <input
-              id="username"
-              value={form.username}
-              onChange={(event) => update("username", event.target.value)}
-              required
-            />
-          </p>
-          <p>
-            <label className="font-17px" htmlFor="first_name">
-              Nome
-            </label>
-            <input
-              id="first_name"
-              value={form.first_name}
-              onChange={(event) => update("first_name", event.target.value)}
-              required
-            />
-          </p>
-          <p>
-            <label className="font-17px" htmlFor="last_name">
-              Sobrenome
-            </label>
-            <input
-              id="last_name"
-              value={form.last_name}
-              onChange={(event) => update("last_name", event.target.value)}
-              required
-            />
-          </p>
-          <p>
-            <label className="font-17px" htmlFor="email">
-              E-mail
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={form.email}
-              onChange={(event) => update("email", event.target.value)}
-              required
-            />
-          </p>
-          <p>
-            <label className="font-17px" htmlFor="password">
-              Senha
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={form.password}
-              onChange={(event) => update("password", event.target.value)}
-              required
-            />
-          </p>
-          <p>
-            <label className="font-17px" htmlFor="city">
-              Cidade
-            </label>
-            <input
-              id="city"
-              value={form.city}
-              onChange={(event) => update("city", event.target.value)}
-              required
-            />
-          </p>
-          <p>
-            <label className="font-17px" htmlFor="state">
-              Estado
-            </label>
-            <select
-              id="state"
-              value={form.state}
-              onChange={(event) => update("state", event.target.value)}
-            >
-              {BRAZIL_STATES.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </p>
-          <p>
-            <label className="font-17px" htmlFor="country">
-              País
-            </label>
-            <select
-              id="country"
-              value={form.country}
-              onChange={(event) => update("country", event.target.value)}
-            >
-              {COUNTRIES.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </p>
+        {step === "form" ? (
+          <form onSubmit={submit}>
+            <p className="font-17px">
+              Não há senha: enviaremos um código de confirmação para o seu
+              e-mail.
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="username">
+                Usuário
+              </label>
+              <input
+                id="username"
+                maxLength={20}
+                value={form.username}
+                onChange={(event) => update("username", event.target.value)}
+                required
+              />
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="name">
+                Nome
+              </label>
+              <input
+                id="name"
+                value={form.name}
+                onChange={(event) => update("name", event.target.value)}
+                required
+              />
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="email">
+                E-mail
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={form.email}
+                onChange={(event) => update("email", event.target.value)}
+                required
+              />
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="phone">
+                Telefone
+              </label>
+              <input
+                id="phone"
+                value={form.phone}
+                onChange={(event) => update("phone", event.target.value)}
+              />
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="city">
+                Cidade
+              </label>
+              <input
+                id="city"
+                value={form.city}
+                onChange={(event) => update("city", event.target.value)}
+                required
+              />
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="state">
+                Estado
+              </label>
+              <select
+                id="state"
+                value={form.state}
+                onChange={(event) => update("state", event.target.value)}
+              >
+                {BRAZIL_STATES.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="country">
+                País
+              </label>
+              <select
+                id="country"
+                value={form.country}
+                onChange={(event) => update("country", event.target.value)}
+              >
+                {COUNTRIES.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </p>
 
-          <button type="submit" className="font-16px" disabled={sending}>
-            <span>{sending ? "Enviando…" : "Cadastrar"}</span>
-          </button>
-        </form>
+            <button type="submit" className="font-16px" disabled={sending}>
+              <span>{sending ? "Enviando…" : "Cadastrar"}</span>
+            </button>
+          </form>
+        ) : (
+          <form onSubmit={confirm}>
+            <p className="font-17px">
+              Enviamos um código para {destination}. Digite-o abaixo para
+              confirmar o seu cadastro.
+            </p>
+            <p>
+              <label className="font-17px" htmlFor="code">
+                Código
+              </label>
+              <input
+                id="code"
+                inputMode="numeric"
+                value={code}
+                onChange={(event) => setCode(event.target.value)}
+                required
+              />
+            </p>
+            <button type="submit" className="font-16px" disabled={sending}>
+              <span>{sending ? "Confirmando…" : "Confirmar"}</span>
+            </button>
+            <button
+              type="button"
+              className="font-16px"
+              onClick={resend}
+              disabled={sending}
+            >
+              <span>Reenviar código</span>
+            </button>
+          </form>
+        )}
       </section>
     </>
   );

--- a/web/src/views/ThingDetail.test.tsx
+++ b/web/src/views/ThingDetail.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/endpoints", () => ({
+  listPrivateThings: vi.fn(),
+  listPublicThings: vi.fn(),
+  readPrivateDetail: vi.fn(),
+  readPublicDetail: vi.fn(),
+}));
+vi.mock("../auth/session", () => ({ readSession: vi.fn() }));
+
+import {
+  listPrivateThings,
+  listPublicThings,
+  readPublicDetail,
+} from "../api/endpoints";
+import { readSession } from "../auth/session";
+import ThingDetail from "./ThingDetail";
+
+const PUBLIC_THING = {
+  thing: "Estufa",
+  uuid: "11111111-1111-1111-1111-111111111111",
+  lastupdate: "---",
+  account: { username: "fulano", city: "Ribeirão Preto", state: "SP", country: "BR" },
+  sensors: [{ id: 1, name: "temperatura" }],
+  thingtags: [],
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/thing/detail/${PUBLIC_THING.uuid}`]}>
+      <Routes>
+        <Route path="/thing/detail/:uuid" element={<ThingDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(listPublicThings).mockReset();
+  vi.mocked(listPrivateThings).mockReset();
+  vi.mocked(readPublicDetail).mockReset().mockResolvedValue([]);
+  vi.mocked(readSession).mockReset();
+});
+
+describe("a public device page visited with a stale session", () => {
+  it("shows the device instead of a session-expired banner", async () => {
+    // Session data is still in localStorage (readSession returns something),
+    // but it is 30+ days old: the private listing rejects the way client.ts
+    // rejects an unrecoverable refresh.
+    vi.mocked(readSession).mockReturnValue({ username: "fulano" });
+    vi.mocked(listPublicThings).mockResolvedValue([PUBLIC_THING]);
+    vi.mocked(listPrivateThings).mockRejectedValue(
+      Object.assign(new Error("Sua sessão expirou. Entre novamente."), {
+        name: "ApiError",
+        status: 401,
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Estufa")).toBeTruthy());
+    // A visitor reading a public device must never see an auth error.
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("an anonymous visitor", () => {
+  it("never calls the private listing at all", async () => {
+    vi.mocked(readSession).mockReturnValue(null);
+    vi.mocked(listPublicThings).mockResolvedValue([PUBLIC_THING]);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Estufa")).toBeTruthy());
+    expect(listPrivateThings).not.toHaveBeenCalled();
+  });
+});
+
+describe("a device that exists in neither listing", () => {
+  it("is reported as not found once both listings have settled", async () => {
+    vi.mocked(readSession).mockReturnValue(null);
+    vi.mocked(listPublicThings).mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("Dispositivo não encontrado.")).toBeTruthy(),
+    );
+  });
+});

--- a/web/src/views/ThingDetail.tsx
+++ b/web/src/views/ThingDetail.tsx
@@ -135,8 +135,14 @@ export default function ThingDetail() {
   const isPublic = Boolean(publicThing);
 
   const loading = publicThings.loading || privateThings.loading;
-  const error = publicThings.error ?? privateThings.error;
-  const settled = Boolean(publicThings.data) && Boolean(privateThings.data);
+  // This route is public: a visitor who never authenticates must be able to
+  // read it. The private listing only enriches the page for a signed-in owner,
+  // so its failure -- including a stale session rejected by the API -- is
+  // never shown here. Only the public listing, which every visitor depends on,
+  // can produce the page-level error.
+  const error = publicThings.error;
+  const privateSettled = Boolean(privateThings.data) || Boolean(privateThings.error);
+  const settled = Boolean(publicThings.data) && privateSettled;
 
   function choosePeriod(next: Period) {
     writePeriod(next);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -62,6 +62,9 @@ export default defineConfig(({ command }) => {
     server: { proxy },
     test: {
       environment: "jsdom",
+      // Exposes the vitest hooks (afterEach, ...) as globals, which the
+      // @testing-library/react auto-cleanup relies on to unmount between tests.
+      globals: true,
       include: ["src/**/*.test.{ts,tsx}"],
     },
   };

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -61,8 +61,8 @@ export default defineConfig(({ command }) => {
     },
     server: { proxy },
     test: {
-      environment: "node",
-      include: ["src/**/*.test.ts"],
+      environment: "jsdom",
+      include: ["src/**/*.test.{ts,tsx}"],
     },
   };
 });


### PR DESCRIPTION
## Resumo

Substitui o portão de sessão decorativo por autenticação real, sem senha: o
usuário informa o e-mail, recebe um código de uso único e o digita. O SPA não
fala com o Cognito — quem intermedia é a API (`SENSORIANDO_API`, PR
correspondente a abrir separadamente).

- ID token só em memória; refresh token (30 dias, sem deslizar) no
  `localStorage` — nenhuma biblioteca de autenticação nova
- `client.ts` injeta o header e renova a sessão com renovação compartilhada
  entre chamadas concorrentes
- Cadastro em duas etapas (formulário → código), já entra logado ao confirmar
- Login em duas etapas (e-mail → código)
- `AuthGate` renova antes de renderizar e reage a uma expiração no meio do
  uso, redirecionando ao login com o motivo
- Perfil, centrais e catálogo de unidades saem de `pending()` e passam a
  consumir a API real; unidade preferida por sensor migra para o
  `localStorage` (não há tabela no schema que ligue conta a unidade)

Spec e plano em `docs/superpowers/specs/` e `docs/superpowers/plans/`
(2026-08-19). Implementado por um agente executor seguindo o handoff em
`docs/superpowers/handoffs/`.

## Revisão

Uma revisão de código encontrou 8 pontos; os 4 mais relevantes foram
corrigidos nesta mesma branch, com TDD para os dois bugs de comportamento:

- `ThingDetail.tsx` não mostra mais um aviso de "sessão expirada" numa
  página pública
- `AuthGate` agora reage a uma expiração de sessão que acontece depois de já
  ter liberado a tela, não só no mount
- Dois comentários/guidelines que tinham ficado desatualizados

Os 4 achados restantes (duplicação de um type guard, uma leitura dupla do
`localStorage`, e duas race conditions de baixo impacto no `client.ts`) ficam
como cleanup opcional, não bloqueante.

## Test plan

- [x] `npm test` — 76 testes, 12 arquivos, todos passando
- [x] `npm run build` (`tsc -b` + `vite build`) sem erro
- [ ] Depende do deploy da fase 1 da API (`SENSORIANDO_API`) e da verificação
      de ponta a ponta documentada no plano dela antes de ir para produção